### PR TITLE
perf: slim lodash imports, drop core-js, tighten chunk budget

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@vee-validate/i18n": "^4.15.1",
     "@vee-validate/rules": "^4.14.7",
     "axios": "^1.16.0",
-    "core-js": "^3.47.0",
     "dayjs": "^1.11.19",
     "diff": "^5.2.0",
     "dompurify": "^3.4.11",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@vee-validate/i18n": "^4.15.1",
     "@vee-validate/rules": "^4.14.7",
     "axios": "^1.16.0",
-    "core-js": "^3.47.0",
     "dayjs": "^1.11.19",
     "diff": "^5.2.0",
     "dompurify": "^3.4.11",

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,7 +4,7 @@
 //   @/i18n - constants, error translations
 //   @/dom-utils - DOM manipulation helpers (postProcessViewerDOM, updateHead)
 
-export { isEqual } from 'lodash';
+export { default as isEqual } from 'lodash/isEqual';
 
 // From @/theme
 export {

--- a/src/components/ExploreSitesGrid.vue
+++ b/src/components/ExploreSitesGrid.vue
@@ -17,7 +17,6 @@ import { api } from '@/api';
 import { ISite, ISiteMap } from '@/interfaces';
 import SiteBtn from '@/components/SiteBtn.vue';
 import BaseCard from '@/components/base/BaseCard.vue';
-import 'core-js/features/array/flat-map';
 import { useMainStore } from '@/stores/main';
 const store = useMainStore();
 

--- a/src/editors/lib-components/TiptapCF.vue
+++ b/src/editors/lib-components/TiptapCF.vue
@@ -156,7 +156,7 @@ import CodeBlockLowlight from '@tiptap/extension-code-block-lowlight';
 import Mention from '@tiptap/extension-mention';
 import { lowlight } from 'lowlight';
 import tippy from 'tippy.js';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 import javascript from 'highlight.js/lib/languages/javascript';
 import css from 'highlight.js/lib/languages/css';
@@ -446,7 +446,7 @@ function getText(): string {
 function getJSON(): object | null {
   if (!editor.value) return null;
   const json = editor.value.getJSON();
-  if (_.isEqual(json, EMPTY_DOCUMENT)) return null;
+  if (isEqual(json, EMPTY_DOCUMENT)) return null;
   return json;
 }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -2,7 +2,7 @@ import { localize } from '@vee-validate/i18n';
 import dayjs from '@/dayjs';
 import { IComment } from '@/interfaces';
 import { env } from '@/env';
-import { range } from 'lodash';
+import range from 'lodash/range';
 
 export { v4 as uuidv4 } from 'uuid';
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -98,16 +98,37 @@ export default defineConfig(({ mode }) => {
       },
     },
     build: {
+      // Enable for Sentry uploads in CI if desired; keep off by default for public builds.
       sourcemap: false,
       rollupOptions: {
         output: {
-          manualChunks: {
-            vendor: ['vue', 'vue-router', 'pinia', 'vuetify'],
+          manualChunks(id) {
+            if (!id.includes('node_modules')) {
+              return;
+            }
+            if (id.includes('vuetify') || id.includes('@mdi')) {
+              return 'vuetify';
+            }
+            if (id.includes('vditor')) {
+              return 'vditor';
+            }
+            if (id.includes('@tiptap') || id.includes('prosemirror') || id.includes('lowlight')) {
+              return 'tiptap';
+            }
+            if (
+              id.includes('/vue/') ||
+              id.includes('vue-router') ||
+              id.includes('pinia') ||
+              id.includes('@vue/')
+            ) {
+              return 'vue-vendor';
+            }
           },
           experimentalMinChunkSize: 10_000,
         },
       },
-      chunkSizeWarningLimit: 2500,
+      // Surface real size regressions; editor chunks are lazy-loaded separately.
+      chunkSizeWarningLimit: 1000,
     },
     server: {
       allowedHosts: true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -128,7 +128,8 @@ export default defineConfig(({ mode }) => {
           experimentalMinChunkSize: 10_000,
         },
       },
-      chunkSizeWarningLimit: 2500,
+      // Largest chunk is ~780 kB; 1000 leaves headroom while surfacing regressions.
+      chunkSizeWarningLimit: 1000,
     },
     server: {
       allowedHosts: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4104,7 +4104,6 @@ __metadata:
     axios: "npm:^1.16.0"
     body-parser: "npm:^1.20.4"
     command-line-args: "npm:^6.0.0"
-    core-js: "npm:^3.47.0"
     css-select: "npm:^5.1.0"
     css-what: "npm:^6.1.0"
     dayjs: "npm:^1.11.19"
@@ -4386,13 +4385,6 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.0"
   checksum: 10c0/71da415899633120db7638dd7b250eee56031f63c4560dcba8eeeafd1168fae171d59b223e3fd2e0aa543a490d64bac7d946764721e2c05897056fdfb22cce33
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.47.0":
-  version: 3.47.0
-  resolution: "core-js@npm:3.47.0"
-  checksum: 10c0/9b1a7088b7c660c7b8f1d4c90bb1816a8d5352ebdcb7bc742e3a0e4eb803316b5aa17bacb8769522342196351a5430178f46914644f2bfdb94ce0ced3c7fd523
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3827,7 +3827,6 @@ __metadata:
     "@vue/test-utils": "npm:^2.4.6"
     autoprefixer: "npm:^10.4.23"
     axios: "npm:^1.16.0"
-    core-js: "npm:^3.47.0"
     dayjs: "npm:^1.11.19"
     diff: "npm:^5.2.0"
     dompurify: "npm:^3.4.11"
@@ -4059,13 +4058,6 @@ __metadata:
   dependencies:
     browserslist: "npm:^4.28.1"
   checksum: 10c0/546e64b7ce45f724825bc13c1347f35c0459a6e71c0dcccff3ec21fbff463f5b0b97fc1220e6d90302153863489301793276fe2bf96f46001ff555ead4140308
-  languageName: node
-  linkType: hard
-
-"core-js@npm:^3.47.0":
-  version: 3.49.0
-  resolution: "core-js@npm:3.49.0"
-  checksum: 10c0/2e42edb47eda38fd5368380131623c8aa5d4a6b42164125b17744bdc08fa5ebbbdd06b4b4aa6ca3663470a560b0f2fba48e18f142dfe264b0039df85bc625694
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Slims lodash imports, drops core-js, and tightens the chunk budget for a leaner bundle.

Independent of `master`; no hard dependency on other stack branches.