### PR TITLE
fix: restore missing icons in account dropdown menu

### DIFF
--- a/src/views/main/Main.vue
+++ b/src/views/main/Main.vue
@@ -185,7 +185,7 @@
                 link
               >
                 <template v-slot:prepend>
-                  <component v-bind:is="item.icon" />
+                  <AppIcon :name="item.icon" />
                 </template>
                 <v-list-item-title>
                   {{ item.text }}
@@ -258,12 +258,12 @@ const { token, userProfile } = useAuth();
 
 const accountItems = [
   {
-    icon: 'DashboardIcon',
+    icon: 'Dashboard',
     text: '个人中心',
     to: '/dashboard',
   },
   {
-    icon: 'ProfileIcon',
+    icon: 'Profile',
     text: '我的主页',
     toRequiresUserProfile: true,
     to: (up: IUserProfile) => `/users/${up.handle}`,


### PR DESCRIPTION
## Problem

The two top rows of the app-bar avatar menu — 个人中心 and 我的主页 — rendered **no icon**, so their labels sat flush against the edge while 问题反馈 and 登出 were indented behind an icon column.

## Cause

`accountItems` declared the icons as strings:

```ts
{ icon: 'DashboardIcon', text: '个人中心', ... }
{ icon: 'ProfileIcon',   text: '我的主页', ... }
```

and the template rendered them via `<component v-bind:is="item.icon" />`.

Neither `DashboardIcon` nor `ProfileIcon` resolves to a registered component anywhere in the tree — nothing imports or registers them. Vue renders an empty node for an unresolvable `:is`, with no error and no production warning, which is why this survived the Vue 2→3 migration unnoticed.

The sibling rows were never broken because they use the real component directly: `<AppIcon name="Feedback" />` and `<AppIcon name="Logout" />`. The actual `iconMap` keys are `Dashboard` and `Profile` — the `Icon` suffix was the whole problem.

## Fix

Use the same `AppIcon` component as the neighbouring rows, with corrected names:

```diff
-  <component v-bind:is="item.icon" />
+  <AppIcon :name="item.icon" />

-  icon: 'DashboardIcon',
+  icon: 'Dashboard',
-  icon: 'ProfileIcon',
+  icon: 'Profile',
```

This also makes future breakage loud rather than silent: `AppIcon` logs `unknown icon name` for a bad key.

## Verification

Built and driven in a real browser (local `vite preview` + seeded auth token). All four rows now report exactly one `<svg>` each, with **no Vue warnings**.

Checked against production cha.fan (`v788a7a67`), which is the visual reference per `CLAUDE.md`. The restored icons match it glyph-for-glyph:

| Row | Icon |
| --- | --- |
| 个人中心 | dashboard grid (`mdiViewDashboard`) |
| 我的主页 | account circle (`mdiAccountCircle`) |
| 问题反馈 | feedback bubble |
| 登出 | X |

So this is a **migration regression against the standing parity goal**, not a feature production never had.

- `vite build` — passes
- `eslint src/views/main/Main.vue` — clean
- `vue-tsc` — 291 errors before and after; **zero introduced**. (The two pre-existing `Main.vue` errors are unrelated: a missing `social_annotations` prop on `Avatar`, and the `to` union type from `toRequiresUserProfile`.)

I also swept `src/` for the same pattern — no other `<component :is>` usages and no other `'XxxIcon'` strings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)