### PR TITLE
fix(pwa): serve fresh builds immediately after deploy

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,37 @@
+# Cloudflare Pages cache policy.
+#
+# Pages' default is a single blanket `public, max-age=300, must-revalidate` for
+# every file, which is wrong in both directions for a Vite build: immutable
+# hashed assets get re-validated every 5 minutes, while the app shell and the
+# service worker can be served up to 5 minutes stale — long enough for a
+# visitor to keep running the previous build after a deploy.
+#
+# Rules are evaluated top to bottom and later matches override earlier ones for
+# the same header, so the catch-all comes first and the specific paths refine it.
+
+# Default: always revalidate. Cheap, because responses carry an ETag, so this
+# is a 304 in the common case rather than a re-download. This also covers the
+# app shell served at arbitrary SPA routes (/questions/..., /articles/...),
+# which is why it has to be the catch-all rather than a rule on /index.html.
+/*
+  Cache-Control: no-cache
+
+# Content-addressed build output: the hash changes whenever the bytes change,
+# so these can never go stale and never need revalidating.
+/assets/*
+  Cache-Control: public, max-age=31536000, immutable
+
+# Static icons and images are not hashed, so they cannot be immutable, but they
+# change rarely enough that a day of browser caching is safe.
+/img/*
+  Cache-Control: public, max-age=86400
+
+# The service worker and its registration decide when clients pick up a new
+# build. Serving these stale delays every deploy for the length of the TTL, so
+# they must always revalidate.
+/sw.js
+  Cache-Control: no-cache
+/registerSW.js
+  Cache-Control: no-cache
+/manifest.webmanifest
+  Cache-Control: no-cache

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,11 +40,32 @@ export default defineConfig(({ mode }) => {
         strategies: 'generateSW',
         workbox: {
           globDirectory: resolve('dist'),
-          globPatterns: ['**/*.{js,css,html,ico,png,svg,woff2}'],
+          // Hashed build output only. index.html is deliberately NOT precached:
+          // precaching it made navigations cache-first, so a returning visitor
+          // got the previous build's HTML (and therefore its asset hashes) for
+          // a whole page view after every deploy.
+          globPatterns: ['**/*.{js,css,ico,png,svg,woff2}'],
           globIgnores: ['**/*.map'],
           skipWaiting: true,
-          navigateFallback: '/index.html',
-          runtimeCaching: [],
+          clientsClaim: true,
+          // Must be an explicit null: vite-plugin-pwa defaults this to
+          // 'index.html', and the generated NavigationRoute would then call
+          // createHandlerBoundToURL on a URL we no longer precache, which
+          // throws non-precached-url at runtime. Cloudflare Pages already
+          // serves the app shell for every SPA route (see public/_redirects),
+          // so navigations go to the network and fall back to cache on failure.
+          navigateFallback: null,
+          runtimeCaching: [
+            {
+              urlPattern: ({ request }) => request.mode === 'navigate',
+              handler: 'NetworkFirst',
+              options: {
+                cacheName: 'html-shell',
+                networkTimeoutSeconds: 3,
+                expiration: { maxEntries: 32 },
+              },
+            },
+          ],
         },
         manifest: {
           name: '茶饭',


### PR DESCRIPTION
After every deploy, a returning visitor kept running the **previous build** until they hard-refreshed. Two independent caching layers each caused this, and fixing only one would have left the other in place.

## 1. Service worker served navigations cache-first

`index.html` was precached and navigations were bound to it:

```js
NavigationRoute(s.createHandlerBoundToURL("index.html"
```

So page loads came from the precache and **never touched the network**. Old HTML means old asset hashes, which means the entire old build.

`registerType: 'autoUpdate'` does not rescue this — it only injects `skipWaiting`/`clientsClaim`. The generated `registerSW.js` is a bare registration with no reload logic:

```js
navigator.serviceWorker.register('/sw.js', { scope: '/' })
```

**Fix:** stop precaching `index.html`; serve navigations `NetworkFirst` with a 3s timeout and an `html-shell` fallback cache. Hashed assets stay precached, so the speed benefit is kept — only the ~2KB shell costs a round trip.

`navigateFallback` must be an **explicit `null`**. vite-plugin-pwa defaults it to `'index.html'`, and simply removing the line left a `NavigationRoute` calling `createHandlerBoundToURL` on a URL that is no longer precached — which throws `non-precached-url` at runtime. Cloudflare Pages already serves the shell for every SPA route via `public/_redirects`, so nothing is lost.

## 2. Cloudflare Pages applied one blanket header to everything

Every file came back as:

```
cache-control: public, max-age=300, must-revalidate
```

Wrong in both directions: immutable hashed assets revalidated every 5 minutes, while the shell, `sw.js` and `registerSW.js` could be served **up to 5 minutes stale** — enough to keep a visitor on the old build and delay the SW update that would rescue them. This would also have blunted fix #1, since the service worker's own `fetch()` goes through the HTTP cache.

**Fix:** a `public/_headers` file.

| Path | Policy | Why |
| --- | --- | --- |
| `/*` | `no-cache` | Always revalidate; ETags make it a cheap 304. Must be the catch-all because the shell is served at arbitrary SPA routes, not just `/index.html`. |
| `/assets/*` | `max-age=31536000, immutable` | Content-addressed — the hash changes when the bytes do. |
| `/img/*` | `max-age=86400` | Not hashed, but changes rarely. |
| `/sw.js`, `/registerSW.js`, `/manifest.webmanifest` | `no-cache` | These decide when clients pick up a new build. |

## Verification

Simulated a real deploy: load build A, swap the server to build B, reload.

| Config | 1st reload after deploy | 2nd reload |
| --- | --- | --- |
| **old** | build A — stale | build A — still stale |
| **new** | **build B — fresh** | build B |

Offline reload still succeeds, served from the `html-shell` cache, so offline capability is retained.

Also confirmed in the generated `dist/sw.js`: no `NavigationRoute`, no `createHandlerBoundToURL`, no html in the precache manifest, `NetworkFirst` + `html-shell` + `networkTimeoutSeconds: 3` present.

- `vitest run` — 113/113 pass
- `vite build` — passes
- `vue-tsc` — 291 errors, unchanged baseline, zero introduced
- `eslint src/` — 0 errors

## Note for review

The `_headers` precedence rule (later matches override earlier ones for the same header) is Cloudflare Pages behaviour that I could not exercise locally — the local simulation hard-coded the intended policy rather than parsing `_headers`. **I'll curl the live headers right after this deploys to preview to confirm `/assets/*` really wins over the `/*` catch-all**, and will reorder if it doesn't.

Separately: Rocket Loader is enabled on the cha.fan zone and rewrites every `<script type=...>` at the edge. It is not causing a problem today, but it provides no benefit for a Vite ESM build and is worth turning off — that's a dashboard setting, not a repo change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)