### PR TITLE
fix(pages): remove overlapping _headers rules that defeat immutable caching

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,37 +1,25 @@
 # Cloudflare Pages cache policy.
 #
-# Pages' default is a single blanket `public, max-age=300, must-revalidate` for
-# every file, which is wrong in both directions for a Vite build: immutable
-# hashed assets get re-validated every 5 minutes, while the app shell and the
-# service worker can be served up to 5 minutes stale — long enough for a
-# visitor to keep running the previous build after a deploy.
+# Only long-lived paths are listed here. Everything else is deliberately left
+# to the Pages default, which is already `public, max-age=0, must-revalidate` —
+# i.e. always revalidate. That is exactly what the app shell, sw.js and
+# registerSW.js need, so restating it would be redundant.
 #
-# Rules are evaluated top to bottom and later matches override earlier ones for
-# the same header, so the catch-all comes first and the specific paths refine it.
+# Rules must not overlap. Pages APPENDS the headers of every matching rule
+# rather than letting the most specific one win, so a `/*` catch-all next to a
+# `/assets/*` rule produces a single combined value:
+#
+#     Cache-Control: no-cache, public, max-age=31536000, immutable
+#
+# where `no-cache` wins and the immutable hint is silently defeated. Keep these
+# patterns disjoint.
 
-# Default: always revalidate. Cheap, because responses carry an ETag, so this
-# is a 304 in the common case rather than a re-download. This also covers the
-# app shell served at arbitrary SPA routes (/questions/..., /articles/...),
-# which is why it has to be the catch-all rather than a rule on /index.html.
-/*
-  Cache-Control: no-cache
-
-# Content-addressed build output: the hash changes whenever the bytes change,
-# so these can never go stale and never need revalidating.
+# Content-addressed build output: the filename hash changes whenever the bytes
+# change, so these can be cached indefinitely and never revalidated.
 /assets/*
   Cache-Control: public, max-age=31536000, immutable
 
-# Static icons and images are not hashed, so they cannot be immutable, but they
+# Icons and static images are not hashed, so they cannot be immutable, but they
 # change rarely enough that a day of browser caching is safe.
 /img/*
   Cache-Control: public, max-age=86400
-
-# The service worker and its registration decide when clients pick up a new
-# build. Serving these stale delays every deploy for the length of the TTL, so
-# they must always revalidate.
-/sw.js
-  Cache-Control: no-cache
-/registerSW.js
-  Cache-Control: no-cache
-/manifest.webmanifest
-  Cache-Control: no-cache


### PR DESCRIPTION
Follow-up to #530, from verifying the live deploy. Two things I assumed there turned out to be wrong.

## 1. Pages appends headers; it does not override

I wrote in #530 that "later matches override earlier ones for the same header." **That is not what Cloudflare Pages does** — it appends the headers of *every* matching rule. Observed on the Pages origin after #530 shipped:

```
/sw.js                    Cache-Control: no-cache, no-cache
/assets/index-*.js        Cache-Control: no-cache, public, max-age=31536000, immutable
```

In that combined value `no-cache` takes precedence, so **hashed assets were being told to revalidate on every request** — the exact opposite of the intent.

The cha.fan zone currently masks this (it rewrites the shorter values, so `/assets/*` still comes back clean through preview.cha.fan), but the Pages origin shows it plainly and that masking shouldn't be relied on.

## 2. The catch-all was unnecessary anyway

Cloudflare Pages' default is already:

```
public, max-age=0, must-revalidate
```

Confirmed against a deployment that predates `_headers`. That is functionally "always revalidate" — exactly what the app shell, `sw.js` and `registerSW.js` need. The `no-cache` rules were restating the default while causing the overlap above.

## Change

Keep only the two disjoint long-lived rules; let everything else fall through to the Pages default:

```
/assets/*
  Cache-Control: public, max-age=31536000, immutable

/img/*
  Cache-Control: public, max-age=86400
```

## Not fixed here: a zone setting

Through preview.cha.fan the shell and `sw.js` still come back as `max-age=300`, even though the origin sends `max-age=0, must-revalidate`:

| Path | Pages origin | via cha.fan zone |
| --- | --- | --- |
| `/` | `max-age=0, must-revalidate` | `max-age=300` |
| `/sw.js` | `max-age=0, must-revalidate` | `max-age=300` |
| `/assets/*` | `max-age=31536000, immutable` | `max-age=31536000, immutable` |

The pattern — shorter values raised to 300s, longer ones left alone — is the zone's **Browser Cache TTL** setting overriding the origin. It needs to be set to **"Respect Existing Headers"** under Caching → Configuration in the dashboard. Until then the browser may hold the shell and the service worker for up to 5 minutes after a deploy.

This is a dashboard change, not a repo change, so it is out of scope for this PR.

## Verification

`vite build` passes and `dist/_headers` contains only the two intended rules. The #530 service-worker change is confirmed live on preview.cha.fan: `NetworkFirst` active, `html-shell` runtime cache created, no `NavigationRoute`/`createHandlerBoundToURL`, no html in the precache manifest, site renders with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)