### PR TITLE
upload: repoint the PWA at the new image endpoint, with purpose, karma and coins

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "html2canvas": "^1.4.1",
     "lodash": "^4.17.21",
     "lowlight": "^2.9.0",
-    "piexifjs": "^1.0.6",
     "pinia": "^2.2.6",
     "prosemirror-state": "^1.4.3",
     "qrious": "^4.0.2",

--- a/src/api/upload.ts
+++ b/src/api/upload.ts
@@ -1,9 +1,22 @@
 import { http } from '@/api/client';
 import { IUploadedImage } from '@/interfaces';
+import { UploadPurpose } from '@/upload';
 import { authHeadersFormData } from '@/utils';
 
 export const apiUpload = {
-  async uploadImage(token: string, payload: FormData) {
+  /**
+   * `purpose` is required in practice even though the server defaults it to
+   * "figure": that default is the karma-gated one, so an avatar sent without
+   * it is refused for any account under MIN_KARMA_UPLOAD_IMAGE.
+   */
+  async uploadImage(token: string, file: Blob, purpose: UploadPurpose, filename?: string) {
+    const payload = new FormData();
+    if (filename) {
+      payload.append('file', file, filename);
+    } else {
+      payload.append('file', file);
+    }
+    payload.append('purpose', purpose);
     return http.post<IUploadedImage>(`/upload/images/`, payload, authHeadersFormData(token));
   },
 };

--- a/src/common.ts
+++ b/src/common.ts
@@ -45,19 +45,5 @@ export const getDefaultNarrowFeedUI = () => {
   }
 };
 
-import { apiUrl } from '@/env';
-
-export const getVditorUploadConfig = (token: string) => {
-  return {
-    max: 1024 * 1024,
-    accept: 'image/png, image/jpeg, image/bmp, image/gif',
-    fieldName: 'files',
-    url: `${apiUrl}/upload/vditor/`,
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  };
-};
-
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 export const doNothing = () => {};

--- a/src/components/AnswerEditor.vue
+++ b/src/components/AnswerEditor.vue
@@ -20,7 +20,7 @@
         :initial-content="topLevelEditor === 'vditor' ? initialContent : undefined"
         :isMobile="!isDesktop"
         :onEditorChange="onEditorChange"
-        :vditorUploadConfig="vditorUploadConfig"
+        :upload="uploadFigure"
         class="mb-2"
         placeholder="谢谢你的贡献！发言前别忘了社区行为守则"
       />
@@ -187,7 +187,7 @@ import {
 } from '@/interfaces';
 import { apiAnswer } from '@/api/answer';
 import VditorCF from '@/editors/lib-components/VditorCF.vue';
-import { getVditorUploadConfig, LABS_TIPTAP_EDITOR_OPTION } from '@/common';
+import { LABS_TIPTAP_EDITOR_OPTION } from '@/common';
 import ChafanTiptap from '@/components/editor/ChafanTiptap.vue';
 import { AnswerEditHandler } from '@/handlers';
 import EditorHelp from '@/components/editor/EditorHelp.vue';
@@ -195,7 +195,7 @@ import DebugSpan from '@/components/base/DebugSpan.vue';
 import Viewer from '@/components/Viewer.vue';
 import RelativeTime from '@/components/RelativeTime.vue';
 import dayjs from '@/dayjs';
-import { useAuth, useResponsive } from '@/composables';
+import { useAuth, useImageUpload, useResponsive } from '@/composables';
 import { useMainStore } from '@/stores/main';
 import { useUiStore } from '@/stores/ui';
 import AppIcon from '@/components/icons/AppIcon.vue';
@@ -272,7 +272,8 @@ const contentId = computed(() => {
   return null;
 });
 
-const vditorUploadConfig = computed(() => getVditorUploadConfig(token.value));
+const { uploadImage } = useImageUpload();
+const uploadFigure = (file: File) => uploadImage(file, 'figure');
 
 function invalidAnswerCallback() {
   logDebug('invalid answer');

--- a/src/components/SimpleEditor.vue
+++ b/src/components/SimpleEditor.vue
@@ -14,7 +14,7 @@
       :initial-value="initialValue"
       :placeholder="placeholder"
       :showMenu="showMenu"
-      :vditorUploadConfig="vditorUploadConfig"
+      :upload="uploadFigure"
     />
   </div>
 </template>
@@ -24,8 +24,7 @@ import { ref, computed } from 'vue';
 import LiteVditorCF from '@/editors/lib-components/LiteVditorCF.vue';
 import ChafanTiptap from '@/components/editor/ChafanTiptap.vue';
 import { editor_T } from '@/interfaces';
-import { getVditorUploadConfig } from '@/common';
-import { useAuth } from '@/composables';
+import { useImageUpload } from '@/composables';
 
 const props = withDefaults(
   defineProps<{
@@ -40,7 +39,7 @@ const props = withDefaults(
   }
 );
 
-const { token } = useAuth();
+const { uploadImage } = useImageUpload();
 
 const tiptap = ref<InstanceType<typeof ChafanTiptap> | null>(null);
 const simpleVditor = ref<any>(null);
@@ -52,9 +51,7 @@ const editor = computed(() => {
   return 'tiptap';
 });
 
-const vditorUploadConfig = computed(() => {
-  return getVditorUploadConfig(token.value);
-});
+const uploadFigure = (file: File) => uploadImage(file, 'figure');
 
 function getContent(): string | null {
   if (editor.value === 'tiptap') {

--- a/src/components/editor/ChafanTiptap.vue
+++ b/src/components/editor/ChafanTiptap.vue
@@ -28,9 +28,8 @@ import 'tippy.js/dist/tippy.css';
 import 'highlight.js/styles/github.css';
 
 import TiptapCF from '@/editors/lib-components/TiptapCF.vue';
-import { resizeImage } from '@/imagelib';
-import { apiUpload } from '@/api/upload';
-import { useAuth } from '@/composables';
+import { useAuth, useImageUpload, useNotification } from '@/composables';
+import { uploadErrorMessage } from '@/upload';
 
 declare const renderMathInElement: (element: HTMLElement, options: Record<string, unknown>) => void;
 
@@ -52,6 +51,8 @@ const props = withDefaults(
 
 const instance = getCurrentInstance();
 const { token } = useAuth();
+const { uploadImage } = useImageUpload();
+const { notifyError } = useNotification();
 
 const base = ref<InstanceType<typeof TiptapCF> | null>(null);
 
@@ -91,23 +92,15 @@ function reset() {
   base.value?.reset();
 }
 
+// Rejecting matters as much as resolving: the editor inserts the resolved URL
+// as an image node, so a failed upload must not resolve with anything.
 async function upload(file: Blob) {
-  const resized = await resizeImage({
-    maxSize: 500, // px
-    file,
-  });
-
-  const formData = new FormData();
-  // Upload candidate image and update URL
   try {
-    const { default: piexif } = await import('piexifjs');
-    formData.append('file', piexif.remove(resized.blob));
-    // Remove EXIF if it is jpeg
-  } catch {
-    formData.append('file', resized.blob);
+    return await uploadImage(file, 'figure');
+  } catch (error: unknown) {
+    notifyError(uploadErrorMessage(error));
+    throw error;
   }
-  const response = await apiUpload.uploadImage(token.value, formData);
-  return response.data.url;
 }
 
 onMounted(() => {

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -4,6 +4,8 @@ export { useResponsive } from './useResponsive';
 export { useNotification } from './useNotification';
 export { useEnv } from './useEnv';
 export { useErrorHandling } from './useErrorHandling';
+export { useImageUpload } from './useImageUpload';
+export type { UploadImageOptions } from './useImageUpload';
 export { AnswerEditHandler, newAnswerHandler } from './useAnswerEditor';
 export type { IVueInstance } from './useAnswerEditor';
 export { newArticleHandler } from './useArticleEditor';

--- a/src/composables/useImageUpload.ts
+++ b/src/composables/useImageUpload.ts
@@ -1,0 +1,114 @@
+import { apiUpload } from '@/api/upload';
+import { resizeImage } from '@/imagelib';
+import { useMainStore } from '@/stores/main';
+import {
+  MIN_KARMA_UPLOAD_IMAGE,
+  UploadError,
+  UploadPurpose,
+  uploadErrorMessage,
+  validateImageFile,
+} from '@/upload';
+
+import { useAuth } from './useAuth';
+import { useNotification } from './useNotification';
+
+/** Longest edge of an image the client sends. The server clamps at 2000px. */
+const MAX_DIMENSION = 500;
+
+export interface UploadImageOptions {
+  /** Downscale to MAX_DIMENSION first. Default true; GIFs are never resized. */
+  resize?: boolean;
+  /** Kept as `original_filename` on the server's upload row. */
+  filename?: string;
+}
+
+/**
+ * Uploading an image to `POST /upload/images/`, with the client-side share of
+ * the contract in `@/upload`.
+ *
+ * Errors never travel as raw AxiosErrors: `store.checkApiError` logs the user
+ * out on 403, and 403 is what the karma gate returns, so an upload refused for
+ * lack of karma would otherwise end the session.
+ */
+export function useImageUpload() {
+  const { token } = useAuth();
+  const { notifyError } = useNotification();
+
+  /**
+   * The karma gate, checked before spending a round trip on bytes the server
+   * will refuse. The profile in the store can be stale — a session outlives
+   * the karma it was loaded with — so it is refetched before refusing, and a
+   * profile we do not have at all defers to the server.
+   */
+  async function figureKarmaRefusal(): Promise<string | null> {
+    const store = useMainStore();
+    if (!store.userProfile || store.userProfile.karma >= MIN_KARMA_UPLOAD_IMAGE) {
+      return null;
+    }
+    await store.getUserProfile();
+    const karma = store.userProfile?.karma ?? 0;
+    if (karma >= MIN_KARMA_UPLOAD_IMAGE) {
+      return null;
+    }
+    return `上传插图需要 ${MIN_KARMA_UPLOAD_IMAGE} Karma（当前 ${karma}）`;
+  }
+
+  async function prepare(file: Blob, options?: UploadImageOptions): Promise<Blob> {
+    // An animated GIF must not go through the canvas resize: it would come
+    // back as a single JPEG frame.
+    if (options?.resize === false || file.type === 'image/gif') {
+      return file;
+    }
+    const resized = await resizeImage({ maxSize: MAX_DIMENSION, file });
+    return resized.blob;
+  }
+
+  /** Upload and return the stored URL. Throws UploadError, message in Chinese. */
+  async function uploadImage(
+    file: Blob,
+    purpose: UploadPurpose,
+    options?: UploadImageOptions
+  ): Promise<string> {
+    if (purpose === 'figure') {
+      const refusal = await figureKarmaRefusal();
+      if (refusal) {
+        throw new UploadError(refusal);
+      }
+    }
+    let body: Blob;
+    try {
+      body = await prepare(file, options);
+    } catch {
+      throw new UploadError('无法读取图片');
+    }
+    const invalid = validateImageFile(body);
+    if (invalid) {
+      throw new UploadError(invalid);
+    }
+    try {
+      const response = await apiUpload.uploadImage(token.value, body, purpose, options?.filename);
+      return response.data.url;
+    } catch (error: unknown) {
+      throw new UploadError(uploadErrorMessage(error));
+    }
+  }
+
+  /** Same, but shows the reason and returns undefined instead of throwing. */
+  async function uploadImageOrNotify(
+    file: Blob,
+    purpose: UploadPurpose,
+    options?: UploadImageOptions
+  ): Promise<string | undefined> {
+    try {
+      return await uploadImage(file, purpose, options);
+    } catch (error: unknown) {
+      notifyError(uploadErrorMessage(error));
+      return undefined;
+    }
+  }
+
+  return {
+    uploadImage,
+    uploadImageOrNotify,
+  };
+}

--- a/src/editors/common.ts
+++ b/src/editors/common.ts
@@ -1,3 +1,5 @@
+import { ACCEPTED_IMAGE_TYPES_ATTR, MAX_IMAGE_BYTES, uploadErrorMessage } from '@/upload';
+
 export const vditorCDN = 'https://cdn.jsdelivr.net/npm/vditor@3.11.2';
 
 export type editor_T =
@@ -6,6 +8,43 @@ export type editor_T =
   | 'markdown'
   | 'markdown_splitview'
   | 'markdown_realtime_rendering';
+
+export type VditorUploadFn = (file: File) => Promise<string>;
+
+/** `]` and `)` in a filename would end the markdown link early. */
+function altText(filename: string): string {
+  return filename.replace(/[[\]()]/g, '') || '图片';
+}
+
+/**
+ * Vditor upload options that send each image through `upload` and insert the
+ * result with `insert`.
+ *
+ * Vditor's own uploader is not used at all. It POSTs a batch under one field
+ * name to a single URL, which is not what `POST /upload/images/` accepts (one
+ * `file`, plus a `purpose`), and the batch endpoint it was written against
+ * (`/upload/vditor/`) no longer exists. Setting `handler` replaces that path
+ * entirely: when one is present Vditor neither validates, uploads, nor inserts,
+ * so all three happen here. A returned string is shown as the editor's tip;
+ * null means handled.
+ */
+export function vditorUploadOptions(upload: VditorUploadFn, insert: (markdown: string) => void) {
+  return {
+    accept: ACCEPTED_IMAGE_TYPES_ATTR,
+    max: MAX_IMAGE_BYTES,
+    handler: async (files: File[]): Promise<string | null> => {
+      for (const file of files) {
+        try {
+          const url = await upload(file);
+          insert(`![${altText(file.name)}](${url})`);
+        } catch (error: unknown) {
+          return uploadErrorMessage(error);
+        }
+      }
+      return null;
+    },
+  };
+}
 
 //https://stackoverflow.com/questions/38241480/detect-macos-ios-windows-android-and-linux-os-with-js
 export function getOS() {

--- a/src/editors/extensions/ImageUpload.ts
+++ b/src/editors/extensions/ImageUpload.ts
@@ -116,9 +116,16 @@ export const Image = Node.create<ImageOptions>({
                 const reader = new FileReader();
 
                 if (upload) {
-                  const node = schema.nodes.image.create({
-                    src: await upload(image),
-                  });
+                  // A refused upload (no karma, no coins, bad bytes) reports
+                  // itself; here it must only leave the document untouched,
+                  // never insert a node and never reject unhandled.
+                  let src: string;
+                  try {
+                    src = await upload(image);
+                  } catch {
+                    return;
+                  }
+                  const node = schema.nodes.image.create({ src });
                   const transaction = view.state.tr.insert(coordinates.pos, node);
                   view.dispatch(transaction);
                 } else {
@@ -148,13 +155,16 @@ export const Image = Node.create<ImageOptions>({
                 const image = item.getAsFile()!;
 
                 if (upload) {
-                  upload(image).then((src) => {
-                    const node = schema.nodes.image.create({
-                      src: src,
-                    });
-                    const transaction = view.state.tr.replaceSelectionWith(node);
-                    view.dispatch(transaction);
-                  });
+                  upload(image)
+                    .then((src) => {
+                      const node = schema.nodes.image.create({
+                        src: src,
+                      });
+                      const transaction = view.state.tr.replaceSelectionWith(node);
+                      view.dispatch(transaction);
+                    })
+                    // Reported by the uploader; nothing to insert.
+                    .catch(() => undefined);
                 } else {
                   const reader = new FileReader();
                   reader.onload = (readerEvent) => {

--- a/src/editors/lib-components/LiteVditorCF.vue
+++ b/src/editors/lib-components/LiteVditorCF.vue
@@ -4,14 +4,14 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
-import { vditorCDN } from '../common';
+import { vditorCDN, vditorUploadOptions, VditorUploadFn } from '../common';
 
 const props = withDefaults(
   defineProps<{
     initialValue?: string;
     placeholder?: string;
     showMenu?: boolean;
-    vditorUploadConfig?: any;
+    upload?: VditorUploadFn;
   }>(),
   {
     showMenu: false,
@@ -26,7 +26,9 @@ async function initVditor() {
   if (vditor !== null) {
     vditor.destroy();
   }
-  vditor = new Vditor(rootEl.value!, {
+  // Typed loosely, like VditorCF: Vditor's own IUpload cannot describe a
+  // handler that resolves to either a message or null.
+  const options: any = {
     cdn: vditorCDN,
     placeholder: props.placeholder ? props.placeholder : '',
     value: props.initialValue,
@@ -48,11 +50,14 @@ async function initVditor() {
     cache: {
       enable: false,
     },
-    upload: props.vditorUploadConfig,
+    upload: props.upload
+      ? vditorUploadOptions(props.upload, (markdown) => vditor?.insertValue(markdown))
+      : undefined,
     counter: {
       enable: false,
     },
-  });
+  };
+  vditor = new Vditor(rootEl.value!, options);
 }
 
 function getText() {

--- a/src/editors/lib-components/VditorCF.vue
+++ b/src/editors/lib-components/VditorCF.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { ref, onMounted, onBeforeUnmount } from 'vue';
 
-import { vditorCDN, editor_T, getOS } from '../common';
+import { vditorCDN, editor_T, getOS, vditorUploadOptions, VditorUploadFn } from '../common';
 
 // Emits:
 // - shortcutSubmit: ctrl-Enter or cmd-Enter
@@ -13,7 +13,7 @@ import { vditorCDN, editor_T, getOS } from '../common';
 const props = withDefaults(
   defineProps<{
     onEditorChange?: (value: string) => void;
-    vditorUploadConfig?: any;
+    upload?: VditorUploadFn;
     isMobile?: boolean;
     initialContent?: string;
     editorMode?: editor_T;
@@ -152,8 +152,8 @@ async function init(editorMode: editor_T, markdownBody?: string, htmlBody?: stri
       }
     },
   };
-  if (props.vditorUploadConfig) {
-    options.upload = props.vditorUploadConfig;
+  if (props.upload) {
+    options.upload = vditorUploadOptions(props.upload, (markdown) => vditor?.insertValue(markdown));
   }
   vditor = new Vditor(rootEl.value!, options);
   window.addEventListener('keydown', shortCutKeyHandler);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -50,6 +50,11 @@ const errorMsgCN: Record<string, string> = {
   'Invalid submission UUID': '分享 UUID 无效',
   'Request failed': '请求失败',
   'Upload requires login': '上传需要登录',
+  // POST /upload/images/ — see @/upload for the status-keyed messages the
+  // upload path itself shows; these cover any other caller of the same API.
+  'Unsupported or invalid image': '不支持的图片格式，请上传 JPEG、PNG、GIF 或 WebP 图片',
+  'File too large': '图片太大，最大 5 MB',
+  'Image uploads are not configured on this server': '本站暂时无法上传图片，请稍后再试',
   "The site doesn't exists in the system": '圈子不存在',
   'Invalid form response id': '无效的表格回答 ID',
   'The site with this subdomain already exists in the system': '该域名的圈子不存在',

--- a/src/upload.ts
+++ b/src/upload.ts
@@ -1,0 +1,124 @@
+/**
+ * Client-side policy for image uploads.
+ *
+ * Every constant here mirrors one in the API (chafan-core) and is a
+ * *pre*-check only: the server enforces all of it again, on bytes it has
+ * sanitized itself. The point of duplicating the numbers is a message in
+ * Chinese before a round trip, not security.
+ *
+ * Server side of the contract (`POST /upload/images/`):
+ *   - multipart with `file` and `purpose` ("figure" | "avatar")
+ *   - "figure" needs MIN_KARMA_UPLOAD_IMAGE karma; "avatar" is exempt
+ *   - new bytes cost UPLOAD_IMAGE_COST coins; identical bytes are free
+ *     (content-addressed by the sha256 of the *sanitized* bytes)
+ *   - the response URL is `{UPLOADS_PUBLIC_URL_BASE}/{sha}.{ext}`
+ */
+import { AxiosError } from 'axios';
+
+import { translateErrorMsgCN } from '@/i18n';
+
+/** What the image is declared to be. Closed set: the server 422s anything else. */
+export type UploadPurpose = 'figure' | 'avatar';
+
+/**
+ * chafan-core `common.MAX_UPLOAD_BYTES`. The server checks it against
+ * Content-Length — the whole multipart body, not just the file — and the
+ * check is strict (`lt`), so the client cap leaves room for the part headers
+ * and the boundary.
+ */
+export const MAX_UPLOAD_BYTES = 5_000_000;
+export const MAX_IMAGE_BYTES = 4_900_000;
+
+/** chafan-core `image_sanitize._SUPPORTED_FORMATS`: anything else is a 415. */
+export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'image/webp'];
+/** For the `accept` attribute of a file input / the Vditor picker. */
+export const ACCEPTED_IMAGE_TYPES_ATTR = ACCEPTED_IMAGE_TYPES.join(', ');
+
+/** chafan-core `rules.MIN_KARMA_UPLOAD_IMAGE`. */
+export const MIN_KARMA_UPLOAD_IMAGE = 100;
+/** chafan-core `rules.UPLOAD_IMAGE_COST`, burned per *new* image. */
+export const UPLOAD_IMAGE_COST = 2;
+
+/**
+ * An upload that failed for a reason worth showing the user, with `message`
+ * already translated. Distinct from a raw AxiosError so callers know the text
+ * is safe to display and that it must not reach `store.checkApiError`, which
+ * logs out on 403 — and 403 is exactly what the karma gate returns.
+ */
+export class UploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'UploadError';
+  }
+}
+
+function megabytes(bytes: number): string {
+  return `${Math.floor(bytes / 100_000) / 10} MB`;
+}
+
+/** A Chinese reason the file cannot be uploaded, or null when it can. */
+export function validateImageFile(file: Blob): string | null {
+  if (file.size === 0) {
+    return '图片是空文件';
+  }
+  if (file.size > MAX_IMAGE_BYTES) {
+    return `图片太大（${megabytes(file.size)}），最大 ${megabytes(MAX_IMAGE_BYTES)}`;
+  }
+  // A Blob built by canvas always has a type; a File picked on an exotic
+  // platform may not. An empty type is left to the server to sniff.
+  if (file.type && !ACCEPTED_IMAGE_TYPES.includes(file.type)) {
+    return '只支持 JPEG、PNG、GIF、WebP 图片';
+  }
+  return null;
+}
+
+function responseDetail(error: AxiosError): string | undefined {
+  const data = error.response?.data as { detail?: unknown; error?: unknown } | undefined;
+  const detail = data?.detail ?? data?.error;
+  return typeof detail === 'string' ? detail : undefined;
+}
+
+/**
+ * Turn an upload failure into a message to show the user.
+ *
+ * Keyed on status rather than on the detail string wherever the server's text
+ * carries a number (the karma gate says "requires 100 karma"), so a change to
+ * that number on the server does not silently fall through to English.
+ */
+export function uploadErrorMessage(error: unknown): string {
+  if (error instanceof UploadError) {
+    return error.message;
+  }
+  const axiosError = error as AxiosError;
+  if (!axiosError?.isAxiosError) {
+    return '图片上传失败';
+  }
+  if (!axiosError.response) {
+    return '无法连接到服务器';
+  }
+  const detail = responseDetail(axiosError);
+  switch (axiosError.response.status) {
+    case 400:
+      // The only 400 on this route is the coin balance. Re-uploading an image
+      // the site already stores is free, so this is about *new* bytes.
+      return `硬币不足，上传新图片需要 ${UPLOAD_IMAGE_COST} 枚硬币`;
+    case 401:
+      return '上传需要登录';
+    case 403:
+      return `上传插图需要 ${MIN_KARMA_UPLOAD_IMAGE} Karma`;
+    case 413:
+      return `图片太大，最大 ${megabytes(MAX_UPLOAD_BYTES)}`;
+    case 415:
+      return '不支持的图片格式，请上传 JPEG、PNG、GIF 或 WebP 图片';
+    case 422:
+      // The Content-Length gate is a header constraint, so an oversize body
+      // is a validation error rather than a 413.
+      return `图片太大或格式无效，最大 ${megabytes(MAX_UPLOAD_BYTES)}`;
+    case 429:
+      return '上传太频繁了，请稍后再试';
+    case 503:
+      return '本站暂时无法上传图片，请稍后再试';
+    default:
+      return detail ? translateErrorMsgCN(detail) : '图片上传失败';
+  }
+}

--- a/src/views/main/ArticleEditor.vue
+++ b/src/views/main/ArticleEditor.vue
@@ -41,7 +41,7 @@
             :initial-content="body"
             :isMobile="!isDesktop"
             :onEditorChange="onEditorChange"
-            :vditorUploadConfig="vditorUploadConfig"
+            :upload="uploadFigure"
             placeholder="开始写作"
             class="mb-2 mt-2"
           />
@@ -170,8 +170,8 @@ import VditorCF from '@/editors/lib-components/VditorCF.vue';
 import ChafanTiptap from '@/components/editor/ChafanTiptap.vue';
 import EditorHelp from '@/components/editor/EditorHelp.vue';
 import ArticleHistoryDialog from '@/components/editor/ArticleHistoryDialog.vue';
-import { getVditorUploadConfig, LABS_TIPTAP_EDITOR_OPTION } from '@/common';
-import { useAuth, useResponsive } from '@/composables';
+import { LABS_TIPTAP_EDITOR_OPTION } from '@/common';
+import { useAuth, useImageUpload, useResponsive } from '@/composables';
 import { useMainStore } from '@/stores/main';
 import AppIcon from '@/components/icons/AppIcon.vue';
 import dayjs from '@/dayjs';
@@ -233,9 +233,8 @@ const articleId = computed(() => {
   return null;
 });
 
-const vditorUploadConfig = computed(() => {
-  return getVditorUploadConfig(token.value);
-});
+const { uploadImage } = useImageUpload();
+const uploadFigure = (file: File) => uploadImage(file, 'figure');
 
 // Methods
 function getEditorMode(): editor_T {

--- a/src/views/main/profile/UserProfileEdit.vue
+++ b/src/views/main/profile/UserProfileEdit.vue
@@ -92,7 +92,7 @@
                       :initial-content="userProfile.about"
                       :isMobile="!isDesktop"
                       :onEditorChange="onEditorChange"
-                      :vditorUploadConfig="vditorUploadConfig"
+                      :upload="uploadFigure"
                     />
                   </div>
                 </v-expand-transition>
@@ -212,22 +212,19 @@
 import { ref, reactive, computed, onMounted } from 'vue';
 import { Form, Field } from 'vee-validate';
 import { useRouter } from 'vue-router';
-import { apiUpload } from '@/api/upload';
 import { apiPeople } from '@/api/people';
 import { editor_T, ITopic, IUserUpdateMe } from '@/interfaces';
-import { resizeImage } from '@/imagelib';
-import piexif from 'piexifjs';
 import { deepCopy, getRecentYears } from '@/utils';
 import { apiMe } from '@/api/me';
 import { apiTopic } from '@/api/topic';
 import { api } from '@/api';
 import VditorCF from '@/editors/lib-components/VditorCF.vue';
-import { getVditorUploadConfig } from '@/common';
+
 import ValidateUrl from '@/components/base/ValidateUrl.vue';
 import ZhihuIcon from '@/components/icons/ZhihuIcon.vue';
 import EducationExperienceSection from '@/components/profile/EducationExperienceSection.vue';
 import WorkExperienceSection from '@/components/profile/WorkExperienceSection.vue';
-import { useAuth, useResponsive } from '@/composables';
+import { useAuth, useImageUpload, useResponsive } from '@/composables';
 import { useMainStore } from '@/stores/main';
 import AppIcon from '@/components/icons/AppIcon.vue';
 import { useNotificationStore } from '@/stores/notifications';
@@ -280,9 +277,8 @@ const vditor = ref<InstanceType<typeof VditorCF> | null>(null);
 const showRemoveConfirm = ref(false);
 const removeCallback = ref<(() => void) | null>(null);
 
-const vditorUploadConfig = computed(() => {
-  return getVditorUploadConfig(store.token);
-});
+const { uploadImage, uploadImageOrNotify } = useImageUpload();
+const uploadFigure = (file: File) => uploadImage(file, 'figure');
 
 onMounted(async () => {
   years.value = getRecentYears();
@@ -462,73 +458,58 @@ function removeFrom<T>(index: number, arr: T[]) {
   arr.splice(index, 1);
 }
 
+// Avatars are uploaded with purpose="avatar", which is exempt from the karma
+// gate on figures -- an account with no karma still gets a profile picture.
+// The upload reports its own failures: an unhandled 403 would reach
+// store.checkApiError and log the user out.
 async function uploadAvatar() {
+  const fileInput = document.getElementById('fileInput') as HTMLInputElement | null;
+  const file = fileInput?.files?.[0];
+  if (!file) {
+    return;
+  }
+  if (file.size <= 128) {
+    useNotificationStore().push({ content: '头像文件过小', color: 'error' });
+    return;
+  }
   uploadAvatarIntermediate.value = true;
-  await store.captureApiError(async () => {
-    const fileInput = document.getElementById('fileInput') as HTMLInputElement | null;
-    if (fileInput !== null) {
-      if (fileInput.files && fileInput.files[0]) {
-        const file = fileInput.files[0];
-        if (file.size <= 128) {
-          useNotificationStore().push({
-            content: '头像文件过小',
-            color: 'error',
-          });
-          uploadAvatarIntermediate.value = false;
-          return;
-        }
-        const formData = new FormData();
-        const resized = await resizeImage({
-          maxSize: 500, // px
-          file,
-        });
-
-        // Upload candidate image and update URL
-        try {
-          formData.append('file', piexif.remove(resized.blob));
-          // Remove EXIF if it is jpeg
-        } catch {
-          formData.append('file', resized.blob);
-        }
-        avatarURL.value = resized.dataUrl;
-        const response = await apiUpload.uploadImage(token.value, formData);
-        userUpdateMe.avatar_url = response.data.url;
-      }
+  try {
+    const url = await uploadImageOrNotify(file, 'avatar', { filename: file.name });
+    if (url) {
+      avatarURL.value = url;
+      userUpdateMe.avatar_url = url;
     }
+  } finally {
     uploadAvatarIntermediate.value = false;
-  });
+  }
 }
 
 async function uploadGifAvatar() {
+  const fileInput = document.getElementById('gifFileInput') as HTMLInputElement | null;
+  const file = fileInput?.files?.[0];
+  if (!file) {
+    return;
+  }
+  if (file.size <= 128) {
+    useNotificationStore().push({ content: '头像文件过小', color: 'error' });
+    return;
+  }
   uploadGifAvatarIntermediate.value = true;
-  await store.captureApiError(async () => {
-    const fileInput = document.getElementById('gifFileInput') as HTMLInputElement;
-    if (fileInput !== null) {
-      if (fileInput.files && fileInput.files[0]) {
-        const file = fileInput.files[0];
-        if (file.size <= 128) {
-          useNotificationStore().push({
-            content: '头像文件过小',
-            color: 'error',
-          });
-          uploadGifAvatarIntermediate.value = false;
-          return;
-        }
-        const formData = new FormData();
-
-        formData.append('file', file);
-
-        const fileReader = new FileReader();
-        fileReader.readAsDataURL(file);
-        fileReader.onload = () => {
-          gifAvatarURL.value = fileReader.result as string;
-        };
-        const response = await apiUpload.uploadImage(token.value, formData);
-        userUpdateMe.gif_avatar_url = response.data.url;
-      }
+  try {
+    // Never resized: the canvas pass would return one flattened JPEG frame,
+    // which is the whole point of this field. The size cap is the only gate,
+    // and it is checked client-side so an oversize GIF says so.
+    const url = await uploadImageOrNotify(file, 'avatar', {
+      resize: false,
+      filename: file.name,
+    });
+    if (url) {
+      gifAvatarURL.value = url;
+      userUpdateMe.gif_avatar_url = url;
     }
+  } finally {
     uploadGifAvatarIntermediate.value = false;
-  });
+  }
 }
 
 function showFilePicker() {

--- a/tests/unit/upload.spec.ts
+++ b/tests/unit/upload.spec.ts
@@ -1,0 +1,273 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+vi.mock('@/env', () => ({
+  apiUrl: 'https://api.test.cha.fan/api/v1',
+  wsUrl: 'wss://api.test.cha.fan/api/v1',
+  env: 'test',
+}));
+
+vi.mock('@/api/upload', () => ({
+  apiUpload: { uploadImage: vi.fn() },
+}));
+
+// The canvas resize cannot run in jsdom; the point under test is only which
+// blob reaches the API, so the fake makes the resized one recognizable.
+vi.mock('@/imagelib', () => ({
+  resizeImage: vi.fn(async () => ({
+    dataUrl: 'data:image/jpeg;base64,',
+    blob: new Blob(['resized'], { type: 'image/jpeg' }),
+  })),
+}));
+
+vi.mock('@/api/me', () => ({
+  apiMe: { getMe: vi.fn(), getModeratedSites: vi.fn(), updateMe: vi.fn() },
+}));
+
+vi.mock('@/utils', () => ({
+  getLocalToken: vi.fn(() => null),
+  saveLocalToken: vi.fn(),
+  removeLocalToken: vi.fn(),
+  isDev: false,
+}));
+
+vi.mock('@sentry/vue', () => ({
+  captureException: vi.fn(),
+  captureMessage: vi.fn(),
+}));
+
+import {
+  MAX_IMAGE_BYTES,
+  MIN_KARMA_UPLOAD_IMAGE,
+  UPLOAD_IMAGE_COST,
+  UploadError,
+  uploadErrorMessage,
+  validateImageFile,
+} from '@/upload';
+import { vditorUploadOptions } from '@/editors/common';
+import { useImageUpload } from '@/composables/useImageUpload';
+import { apiUpload } from '@/api/upload';
+import { resizeImage } from '@/imagelib';
+import { useMainStore } from '@/stores/main';
+import { useNotificationStore } from '@/stores/notifications';
+
+function blobOfSize(size: number, type = 'image/png'): Blob {
+  return new Blob([new Uint8Array(size)], { type });
+}
+
+function axiosError(status: number, detail?: string) {
+  return {
+    isAxiosError: true,
+    message: `Request failed with status code ${status}`,
+    response: { status, data: detail === undefined ? {} : { detail } },
+  };
+}
+
+describe('validateImageFile', () => {
+  it('accepts an image inside the cap', () => {
+    expect(validateImageFile(blobOfSize(1000, 'image/jpeg'))).toBeNull();
+  });
+
+  it('rejects an empty file', () => {
+    expect(validateImageFile(blobOfSize(0))).toBe('图片是空文件');
+  });
+
+  it('rejects a file over the cap', () => {
+    const message = validateImageFile(blobOfSize(MAX_IMAGE_BYTES + 1));
+    expect(message).toContain('图片太大');
+  });
+
+  it('rejects a format the server cannot decode', () => {
+    expect(validateImageFile(blobOfSize(1000, 'image/bmp'))).toBe(
+      '只支持 JPEG、PNG、GIF、WebP 图片'
+    );
+  });
+
+  it('defers to the server when the blob has no type', () => {
+    expect(validateImageFile(blobOfSize(1000, ''))).toBeNull();
+  });
+});
+
+describe('uploadErrorMessage', () => {
+  it('passes an already-translated UploadError through', () => {
+    expect(uploadErrorMessage(new UploadError('图片是空文件'))).toBe('图片是空文件');
+  });
+
+  it('names the coin cost on 400', () => {
+    expect(uploadErrorMessage(axiosError(400, 'Insufficient coins.'))).toContain(
+      `${UPLOAD_IMAGE_COST} 枚硬币`
+    );
+  });
+
+  it('names the karma gate on 403 rather than echoing the server number', () => {
+    expect(uploadErrorMessage(axiosError(403, 'Uploading a figure requires 100 karma.'))).toBe(
+      `上传插图需要 ${MIN_KARMA_UPLOAD_IMAGE} Karma`
+    );
+  });
+
+  it('translates the format refusal on 415', () => {
+    expect(uploadErrorMessage(axiosError(415, 'Unsupported or invalid image.'))).toContain(
+      '不支持的图片格式'
+    );
+  });
+
+  it('reads an oversize body out of the 422 from the Content-Length gate', () => {
+    expect(uploadErrorMessage(axiosError(422))).toContain('图片太大');
+  });
+
+  it('explains a rate limit', () => {
+    expect(uploadErrorMessage(axiosError(429, 'Rate limit exceeded: 20 per 1 hour'))).toBe(
+      '上传太频繁了，请稍后再试'
+    );
+  });
+
+  it('explains an unconfigured server', () => {
+    expect(uploadErrorMessage(axiosError(503))).toContain('无法上传图片');
+  });
+
+  it('reports a lost connection', () => {
+    expect(uploadErrorMessage({ isAxiosError: true, message: 'Network Error' })).toBe(
+      '无法连接到服务器'
+    );
+  });
+
+  it('translates an unrecognized detail', () => {
+    expect(uploadErrorMessage(axiosError(409, 'Inactive user'))).toBe('账户已暂停');
+  });
+
+  it('falls back for anything that is not an upload failure', () => {
+    expect(uploadErrorMessage(new Error('boom'))).toBe('图片上传失败');
+  });
+});
+
+describe('useImageUpload', () => {
+  const uploadImageApi = apiUpload.uploadImage as unknown as ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    uploadImageApi.mockResolvedValue({ data: { url: 'https://uploads.cha.fan/abc.jpg' } });
+  });
+
+  function withProfile(karma: number) {
+    const store = useMainStore();
+    store.userProfile = { karma } as never;
+    return store;
+  }
+
+  it('sends purpose=figure and the resized blob', async () => {
+    withProfile(MIN_KARMA_UPLOAD_IMAGE);
+    const { uploadImage } = useImageUpload();
+
+    const url = await uploadImage(blobOfSize(1000, 'image/png'), 'figure');
+
+    expect(url).toBe('https://uploads.cha.fan/abc.jpg');
+    expect(resizeImage).toHaveBeenCalledTimes(1);
+    const [, file, purpose] = uploadImageApi.mock.calls[0];
+    expect(purpose).toBe('figure');
+    expect(file.type).toBe('image/jpeg');
+  });
+
+  it('refuses a figure below the karma gate without calling the API', async () => {
+    withProfile(MIN_KARMA_UPLOAD_IMAGE - 1);
+    const { uploadImage } = useImageUpload();
+
+    await expect(uploadImage(blobOfSize(1000), 'figure')).rejects.toThrow(
+      `上传插图需要 ${MIN_KARMA_UPLOAD_IMAGE} Karma（当前 ${MIN_KARMA_UPLOAD_IMAGE - 1}）`
+    );
+    expect(uploadImageApi).not.toHaveBeenCalled();
+  });
+
+  it('exempts avatars from the karma gate', async () => {
+    withProfile(0);
+    const { uploadImage } = useImageUpload();
+
+    await uploadImage(blobOfSize(1000), 'avatar');
+
+    expect(uploadImageApi.mock.calls[0][2]).toBe('avatar');
+  });
+
+  it('never resizes a GIF, so the animation survives', async () => {
+    withProfile(0);
+    const { uploadImage } = useImageUpload();
+
+    await uploadImage(blobOfSize(1000, 'image/gif'), 'avatar');
+
+    expect(resizeImage).not.toHaveBeenCalled();
+    expect(uploadImageApi.mock.calls[0][1].type).toBe('image/gif');
+  });
+
+  it('checks the size of what it actually sends', async () => {
+    withProfile(0);
+    const { uploadImage } = useImageUpload();
+
+    await expect(
+      uploadImage(blobOfSize(MAX_IMAGE_BYTES + 1, 'image/gif'), 'avatar', { resize: false })
+    ).rejects.toThrow(UploadError);
+    expect(uploadImageApi).not.toHaveBeenCalled();
+  });
+
+  it('translates a server refusal instead of leaking the AxiosError', async () => {
+    withProfile(MIN_KARMA_UPLOAD_IMAGE);
+    uploadImageApi.mockRejectedValue(axiosError(400, 'Insufficient coins.'));
+    const { uploadImage } = useImageUpload();
+
+    // An AxiosError escaping here would reach store.checkApiError, which logs
+    // the user out on 401/403.
+    await expect(uploadImage(blobOfSize(1000), 'figure')).rejects.toBeInstanceOf(UploadError);
+  });
+
+  it('notifies and returns undefined in the non-throwing variant', async () => {
+    withProfile(MIN_KARMA_UPLOAD_IMAGE);
+    uploadImageApi.mockRejectedValue(axiosError(415, 'Unsupported or invalid image.'));
+    const { uploadImageOrNotify } = useImageUpload();
+
+    const url = await uploadImageOrNotify(blobOfSize(1000), 'figure');
+
+    expect(url).toBeUndefined();
+    const notifications = useNotificationStore().notifications;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].content).toContain('不支持的图片格式');
+    expect(notifications[0].color).toBe('error');
+  });
+});
+
+describe('vditorUploadOptions', () => {
+  const png = () => new File([new Uint8Array(10)], 'a.png', { type: 'image/png' });
+
+  it('inserts each uploaded image as markdown and reports success with null', async () => {
+    const inserted: string[] = [];
+    const options = vditorUploadOptions(
+      async () => 'https://uploads.cha.fan/abc.png',
+      (markdown) => inserted.push(markdown)
+    );
+
+    await expect(options.handler([png()])).resolves.toBeNull();
+    expect(inserted).toEqual(['![a.png](https://uploads.cha.fan/abc.png)']);
+  });
+
+  it('strips brackets out of the alt text so the link cannot end early', async () => {
+    const inserted: string[] = [];
+    const options = vditorUploadOptions(
+      async () => 'https://uploads.cha.fan/abc.png',
+      (markdown) => inserted.push(markdown)
+    );
+
+    await options.handler([new File([new Uint8Array(10)], 'a](x).png', { type: 'image/png' })]);
+
+    expect(inserted).toEqual(['![ax.png](https://uploads.cha.fan/abc.png)']);
+  });
+
+  it('returns the reason as a string, which Vditor shows as a tip', async () => {
+    const inserted: string[] = [];
+    const options = vditorUploadOptions(
+      async () => {
+        throw new UploadError('硬币不足');
+      },
+      (markdown) => inserted.push(markdown)
+    );
+
+    await expect(options.handler([png()])).resolves.toBe('硬币不足');
+    expect(inserted).toEqual([]);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3840,7 +3840,6 @@ __metadata:
     lint-staged: "npm:^15.2.10"
     lodash: "npm:^4.17.21"
     lowlight: "npm:^2.9.0"
-    piexifjs: "npm:^1.0.6"
     pinia: "npm:^2.2.6"
     postcss: "npm:^8.5.6"
     postcss-html: "npm:^1.8.0"
@@ -7055,13 +7054,6 @@ __metadata:
   bin:
     pidtree: bin/pidtree.js
   checksum: 10c0/6abf7ab04941e6ac44cc55e9aca800aba4769407e8faf1d28a8adce44bfca1a0060c1e7c662c2641241c67367a80fc768d71a35391d7e5ffd15f0ee7d5ea74e0
-  languageName: node
-  linkType: hard
-
-"piexifjs@npm:^1.0.6":
-  version: 1.0.6
-  resolution: "piexifjs@npm:1.0.6"
-  checksum: 10c0/69a10fe09c08f1e67e653844ac79e720324a7fa34689b020359d60d98b3a601c070e1759df8f2d97d022298bd2f5b79eed4c92de86c5f215300c8a63adf947b1
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Client side of the image-upload work that landed in chafan-core (#191–#199). The API is now one route, `POST /upload/images/`, taking a `purpose` form field (`figure` | `avatar`), gated on karma for figures, priced in coins for new bytes, content-addressed so the same image again is free. `/upload/vditor/` is deleted.

## What was broken

- **Avatars would have been karma-gated.** The server defaults `purpose` to `figure` — the gated value — so an avatar sent without the field is refused for every account under 100 karma, including every new one. Avatars now declare themselves.
- **Vditor image upload posts to a deleted endpoint.** Vditor is still the default editor for answers and articles (Tiptap is behind the labs flag), and its uploader batches files under one field name to `/upload/vditor/`. `vditorUploadOptions` (`src/editors/common.ts`) replaces it with a `handler` that posts one file at a time and inserts the markdown itself. Setting a handler also disables Vditor's own size/accept validation, so the handler does it.
- **A refused upload could log the user out.** `store.checkApiError` logs out on 401/403, and 403 is exactly what the karma gate returns. Nothing on this path lets an AxiosError escape any more — failures are wrapped in `UploadError` with the message already translated.

## What's new

- `src/upload.ts` — client-side policy mirroring the server's numbers (5 MB, JPEG/PNG/GIF/WebP, karma 100, 2 coins) plus status→message mapping. A pre-check for a Chinese message before a round trip, not security: the server enforces all of it again, on bytes it has sanitized itself.
- `src/composables/useImageUpload.ts` — `uploadImage` (throws `UploadError`) and `uploadImageOrNotify` (notifies, returns `undefined`). The karma pre-check refetches the profile before refusing, since a session outlives the karma it was loaded with.
- Tiptap drop/paste no longer inserts a node — or rejects unhandled — when an upload fails.

## Incidental

- A GIF is never resized: the canvas pass returns one flattened JPEG frame, which defeats the point of the GIF avatar field. The size cap is the only gate there, so it is checked client-side.
- `piexifjs` deleted. `piexif.remove()` wants a binary string and was being handed a `Blob`, so it always threw into the fallback — and both the canvas re-encode and the server's sanitizer drop metadata anyway.

## Verification

`vite build` clean, `vue-tsc` two errors below baseline and none added, eslint 0 errors, 138 unit tests pass (25 new, covering the policy, the status mapping and the Vditor handler).

Driven in a real browser against a local API: still avatar (`purpose=avatar`, resized), GIF avatar (`purpose=avatar`, untouched bytes, stored as `.gif`), Vditor figure (`purpose=figure`, rendered in the editor), and a 5.1 MB file refused client-side with no request sent.

## Worth knowing

`rules.INITIAL_USER_COINS = 0` on the server and coins are charged for any new image, avatars included — so a brand-new account cannot upload a profile picture and gets 「硬币不足」. That is the backend TODO already noted in `rules.py`, but it lands here as UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)