### PR TITLE
fix: stop rendering one hardcoded avatar for every user

### DIFF
--- a/e2e/helpers/app.ts
+++ b/e2e/helpers/app.ts
@@ -10,10 +10,10 @@ export async function waitForApp(page: Page) {
   await expect(appRoot(page)).toBeVisible({ timeout: 30_000 });
 }
 
-/** Ensure Pinia finished checkLoggedIn (avatar appears when profile is loaded). */
+/** Ensure Pinia finished checkLoggedIn (the account button appears with the profile). */
 export async function waitForLoggedInShell(page: Page) {
   await waitForApp(page);
-  await expect(page.getByRole('button', { name: 'Avatar' })).toBeVisible({ timeout: 30_000 });
+  await expect(page.locator('#main-menu-avatar-btn')).toBeVisible({ timeout: 30_000 });
   await expect(page.getByRole('link', { name: '用户中心' })).toBeVisible({ timeout: 15_000 });
 }
 

--- a/e2e/journeys/05-logout.spec.ts
+++ b/e2e/journeys/05-logout.spec.ts
@@ -31,7 +31,7 @@ test.describe('Logout', () => {
 
 /** Open the avatar menu and click 登出. Returns true if the token cleared. */
 async function logoutViaMenu(page: import('@playwright/test').Page): Promise<boolean> {
-  await clickVuetifyButton(page.getByRole('button', { name: 'Avatar' }));
+  await clickVuetifyButton(page.locator('#main-menu-avatar-btn'));
 
   const logout = page
     .locator('.v-overlay--active .v-list-item, .v-menu .v-list-item')

--- a/src/components/Avatar.vue
+++ b/src/components/Avatar.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import { IUserPreview } from '@/interfaces';
-import { isDev, isProdDev } from '@/utils';
 
 const DEFAULT_URL = '/img/default-avatar.png';
 
@@ -15,9 +14,7 @@ const props = withDefaults(defineProps<{
 });
 
 const url = computed(() => {
-  if (isDev && !isProdDev) {
-    return 'https://cdn.jsdelivr.net/npm/programming-languages-logos/src/c/c.png';
-  } else if (props.userPreview) {
+  if (props.userPreview) {
     return props.userPreview.avatar_url ? props.userPreview.avatar_url : DEFAULT_URL;
   } else if (props.avatarUrl) {
     return props.avatarUrl;

--- a/src/views/main/Main.vue
+++ b/src/views/main/Main.vue
@@ -169,7 +169,7 @@
                 icon
               >
                 <Avatar
-                  v-if="userProfile && (userProfile.avatar_url || isDev)"
+                  v-if="userProfile && userProfile.avatar_url"
                   :userPreview="userProfile"
                   color="primary"
                 />
@@ -232,7 +232,6 @@ import { useRoute, useRouter } from 'vue-router';
 
 import { appName } from '@/env';
 import { api } from '@/api';
-import { isDev } from '@/utils';
 import { useMainStore } from '@/stores/main';
 import { useUiStore } from '@/stores/ui';
 


### PR DESCRIPTION
## Related issues/discussions

None filed — reported directly: "currently everyone has the same avatar".

## Description of the changes

`Avatar.vue` returned a hardcoded jsdelivr C-logo for **every** user whenever `isDev && !isProdDev`:

```ts
if (isDev && !isProdDev) {
  return 'https://cdn.jsdelivr.net/npm/programming-languages-logos/src/c/c.png';
}
```

That condition reads like "local dev only", but it isn't:

- `isDev = env !== 'production' || hostname === 'dev.cha.fan'` — true for any build not made with `VITE_APP_ENV=production`
- `isProdDev = hostname === 'dev.cha.fan'` — so the override is *off* on dev.cha.fan and *on* everywhere else non-prod

preview.cha.fan is built with `VUE_APP_ENV=staging`, so this was live for every visitor there. Production is unaffected only because cha.fan still serves the pre-migration Vue 2 build — it would have started the moment the Vue 3 tree was promoted, unless that Cloudflare project happened to set `production`.

Confirmed against the **deployed** preview bundle rather than inferred: `assets/index-*.js` ships `const _L="staging"`, `isDev` folded to `true` at build time (`logDebug` is emitted as a bare `console.log`, guard eliminated), and the placeholder URL sits in the `UserLink` chunk with only the `isProdDev` check left at runtime.

The placeholder predates the Vue 3 migration — it goes back to `19979b8`.

### Changes

| file | change |
| --- | --- |
| `src/components/Avatar.vue` | dropped the dev override; the fallback is `/img/default-avatar.png`, which is what avatar-less users were always meant to get |
| `src/views/main/Main.vue` | dropped `\|\| isDev` from the toolbar gate — the placeholder's companion, which forced the fake avatar for accounts with no `avatar_url`. Prod shows the Account icon there. |
| `e2e/helpers/app.ts`, `e2e/journeys/05-logout.spec.ts` | locate the account button by `#main-menu-avatar-btn` rather than by accessible name `"Avatar"` |

The e2e change is required, not cosmetic. The test account has no `avatar_url`, and `isDev` was the only reason `<Avatar>` rendered for it on preview at all; with the gate gone the button correctly falls back to the Account icon, so a name-based locator would break the login and logout journeys. The id-based locator does not depend on whether the account has uploaded an avatar.

### Verification

- `vite build` clean · `vitest run` 138/138 · `eslint src/ e2e/` 0 errors
- `vue-tsc`: 289 errors before and after — identical baseline, including the two pre-existing ones in `Main.vue`
- grepped a fresh build made with the worst case `VITE_APP_ENV=development`: **zero** occurrences of the placeholder URL in `dist/`

### Not in scope

`Avatar.vue` ignores `gif_avatar_url` entirely, even though `IUserPreview` carries it and `UserProfileEdit` uploads it — animated avatars never render outside the profile editor. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ADREGb162QbFya7G55BEL
