### PR TITLE
feat: add /link, the page that binds a bot to an account

### DIFF
--- a/src/api/me.ts
+++ b/src/api/me.ts
@@ -2,6 +2,7 @@ import { http } from '@/api/client';
 import { authHeaders, authHeadersWithParams } from '../utils';
 import {
   IAnswerPreview,
+  IBotLinkCode,
   IArticlePreview,
   IChannel,
   IQuestionPreview,
@@ -33,6 +34,13 @@ function addSchemeToUrl(url: string | undefined) {
 export const apiMe = {
   async getMe(token: string) {
     return http.get<IUserProfile>(`/me`, authHeaders(token));
+  },
+  // Issues a short-lived code to hand to a bot. The code travels site -> bot
+  // and never the other way: it appears on the screen of whoever is logged in
+  // here, so the account that gets bound is always the one that asked for it.
+  // No token exists until the bot redeems the code.
+  async createBotLinkCode(token: string) {
+    return http.post<IBotLinkCode>(`/me/bot-link-codes/`, {}, authHeaders(token));
   },
   async updateMe(token: string, data: IUserUpdateMe) {
     data.zhihu_url = addSchemeToUrl(data.zhihu_url);

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -11,6 +11,7 @@ export const constants = {
   reset_password: '重置密码',
   invitation_to_join: '邀请加入',
   search_results: '搜索结果',
+  link_bot: '绑定机器人',
 };
 
 export const INSUFFICIENT_KARMA_TO_JOIN_SITE = '加入圈子所需的 Karma 不足';

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -672,6 +672,11 @@ export interface IGenericResponse {
   success: boolean;
 }
 
+export interface IBotLinkCode {
+  code: string;
+  expires_in_seconds: number;
+}
+
 export interface IUploadedImage {
   url: string;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -174,6 +174,13 @@ const routes: RouteRecordRaw[] = [
     ] /* children of main */,
   },
   {
+    path: '/link',
+    meta: {
+      title: constants.link_bot,
+    },
+    component: () => import('./views/BotLink.vue'),
+  },
+  {
     path: '/login',
     meta: {
       title: constants.login,

--- a/src/views/BotLink.vue
+++ b/src/views/BotLink.vue
@@ -1,0 +1,179 @@
+<template>
+  <v-container fluid>
+    <v-row justify="center">
+      <v-col :class="{ 'v-col-8': display.mdAndUp }">
+        <v-card class="ma-3 pa-3" variant="outlined">
+          <v-card-title>
+            <div class="text-h5 text-primary">绑定{{ botLabel }}</div>
+          </v-card-title>
+
+          <!-- Logged out: the whole point of this page is that the code
+               appears on the screen of someone already signed in, so there is
+               nothing to show until they are. -->
+          <v-card-text v-if="!loggedIn">
+            <p class="mb-4">生成绑定码需要先登录。</p>
+            <v-btn color="primary" variant="flat" :to="loginTarget">去登录</v-btn>
+          </v-card-text>
+
+          <v-card-text v-else>
+            <p class="mb-4">
+              点下面的按钮生成一个绑定码，然后把它发给{{ botLabel }}。绑定码只在
+              {{ expiryMinutes }} 分钟内有效，用一次就失效。
+            </p>
+
+            <div v-if="code" class="mb-4">
+              <div class="text-medium-emphasis mb-1">你的绑定码</div>
+              <div class="d-flex align-center flex-wrap ga-2">
+                <code class="link-code">{{ code }}</code>
+                <v-btn size="small" variant="text" @click="copy">
+                  {{ copied ? '已复制' : '复制' }}
+                </v-btn>
+              </div>
+              <div class="text-medium-emphasis mt-2">
+                <template v-if="secondsLeft > 0">
+                  {{ formattedTimeLeft }}后失效。只发给{{ botLabel }}，不要发给任何人。
+                </template>
+                <template v-else> 已失效，请重新生成。 </template>
+              </div>
+            </div>
+
+            <v-alert v-if="errorMessage" type="error" variant="tonal" class="mb-4">
+              {{ errorMessage }}
+            </v-alert>
+
+            <v-btn
+              color="primary"
+              variant="flat"
+              :loading="loading"
+              :disabled="loading"
+              @click="generate"
+            >
+              {{ code ? '重新生成绑定码' : '生成绑定码' }}
+            </v-btn>
+          </v-card-text>
+
+          <v-divider />
+
+          <v-card-text class="text-medium-emphasis">
+            <p class="mb-1">绑定后，机器人可以代你在茶饭上发表内容。</p>
+            <p class="mb-0">
+              它只看得到你输入给它的命令，读不到任何聊天记录。想解除绑定，在机器人那里运行
+              <code>/chafan unlink</code>。
+            </p>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+  </v-container>
+</template>
+
+<script setup lang="ts">
+import { computed, onUnmounted, ref } from 'vue';
+import { useDisplay } from 'vuetify';
+import { useRoute } from 'vue-router';
+import { AxiosError } from 'axios';
+import { apiMe } from '@/api/me';
+import { useAuth, useErrorHandling } from '@/composables';
+
+const display = useDisplay();
+const route = useRoute();
+const { token, loggedIn } = useAuth();
+const { commitErrMsg } = useErrorHandling();
+
+const code = ref<string | null>(null);
+const secondsLeft = ref(0);
+const loading = ref(false);
+const copied = ref(false);
+const errorMessage = ref<string | null>(null);
+let ticker: ReturnType<typeof setInterval> | null = null;
+
+// `?from=discord` only changes what the page calls the bot. It is never used to
+// decide anything: whoever holds a configured secret can redeem the code, and
+// this page has no way to know which bot the user will hand it to.
+const KNOWN_BOTS: Record<string, string> = {
+  discord: 'Discord 机器人',
+};
+const botLabel = computed(() => {
+  const from = route.query.from;
+  return (typeof from === 'string' && KNOWN_BOTS[from]) || '机器人';
+});
+
+const loginTarget = computed(() => ({
+  path: '/login',
+  query: { redirect: route.fullPath },
+}));
+
+const expiryMinutes = ref(10);
+
+const formattedTimeLeft = computed(() => {
+  const minutes = Math.floor(secondsLeft.value / 60);
+  const seconds = secondsLeft.value % 60;
+  if (minutes > 0) {
+    return `${minutes} 分 ${seconds.toString().padStart(2, '0')} 秒`;
+  }
+  return `${seconds} 秒`;
+});
+
+function startCountdown(seconds: number) {
+  secondsLeft.value = seconds;
+  if (ticker) {
+    clearInterval(ticker);
+  }
+  ticker = setInterval(() => {
+    secondsLeft.value -= 1;
+    if (secondsLeft.value <= 0 && ticker) {
+      clearInterval(ticker);
+      ticker = null;
+    }
+  }, 1000);
+}
+
+onUnmounted(() => {
+  if (ticker) {
+    clearInterval(ticker);
+  }
+});
+
+async function generate() {
+  loading.value = true;
+  errorMessage.value = null;
+  copied.value = false;
+  try {
+    const response = await apiMe.createBotLinkCode(token.value);
+    code.value = response.data.code;
+    expiryMinutes.value = Math.max(1, Math.round(response.data.expires_in_seconds / 60));
+    startCountdown(response.data.expires_in_seconds);
+  } catch (error) {
+    errorMessage.value = '生成绑定码失败，请稍后再试。';
+    commitErrMsg(error as AxiosError);
+  } finally {
+    loading.value = false;
+  }
+}
+
+async function copy() {
+  if (!code.value) {
+    return;
+  }
+  try {
+    await navigator.clipboard.writeText(code.value);
+    copied.value = true;
+  } catch {
+    // Clipboard access is denied over plain http and in some embedded
+    // browsers. The code is on screen and short enough to retype, so this is
+    // not worth an error message.
+    copied.value = false;
+  }
+}
+</script>
+
+<style scoped>
+.link-code {
+  font-size: 1.6rem;
+  letter-spacing: 0.2em;
+  padding: 0.3em 0.6em;
+  border-radius: 4px;
+  background-color: rgb(var(--v-theme-surface-variant), 0.25);
+  user-select: all;
+}
+</style>

--- a/tests/unit/bot-link.spec.ts
+++ b/tests/unit/bot-link.spec.ts
@@ -1,20 +1,34 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { apiMe } from '@/api/me';
-import { http } from '@/api/client';
-import router from '@/router';
 
 vi.mock('@/api/client', () => ({
   http: { post: vi.fn(() => Promise.resolve({ data: {} })) },
 }));
 
+// Both the api module and the router reach env.ts through src/utils, and
+// env.ts refuses to load without a valid VITE_APP_API. A developer has one in
+// .env and CI does not, so the env is set before anything is imported and
+// every import here is dynamic. env.spec.ts uses the same shape.
+async function withEnv<T>(load: () => Promise<T>): Promise<T> {
+  (import.meta.env as Record<string, string>).VITE_APP_API = 'api.cha.fan';
+  (import.meta.env as Record<string, string>).VITE_APP_ENV = 'test';
+  return load();
+}
+
 describe('bot link code', () => {
   beforeEach(() => {
-    vi.mocked(http.post).mockClear();
+    vi.resetModules();
   });
 
-  it('asks the API as the logged-in user', async () => {
+  async function callCreate() {
+    const { apiMe } = await withEnv(() => import('@/api/me'));
+    const { http } = await import('@/api/client');
+    vi.mocked(http.post).mockClear();
     await apiMe.createBotLinkCode('test-token-123');
-    const [path, body, config] = vi.mocked(http.post).mock.calls[0];
+    return vi.mocked(http.post).mock.calls[0];
+  }
+
+  it('asks the API as the logged-in user', async () => {
+    const [path, body, config] = await callCreate();
     expect(path).toBe('/me/bot-link-codes/');
     // Authenticated, because the code must only ever be issued to whoever is
     // already signed in as the account being bound.
@@ -25,20 +39,28 @@ describe('bot link code', () => {
   it('sends no identifier for the bot', async () => {
     // The backend never learns which platform is asking: the mapping from a
     // platform account to a token lives in the bot, so nothing here names one.
-    await apiMe.createBotLinkCode('test-token-123');
-    const [, body] = vi.mocked(http.post).mock.calls[0];
+    const [, body] = await callCreate();
     expect(JSON.stringify(body)).not.toMatch(/discord|telegram/i);
   });
 });
 
 describe('/link route', () => {
-  it('resolves, so the URL the bot prints actually lands somewhere', () => {
-    const resolved = router.resolve('/link');
-    expect(resolved.matched.length).toBeGreaterThan(0);
+  beforeEach(() => {
+    vi.resetModules();
   });
 
-  it('carries ?from through, which is all that query is for', () => {
+  async function loadRouter() {
+    return (await withEnv(() => import('@/router'))).default;
+  }
+
+  it('resolves, so the URL the bot prints actually lands somewhere', async () => {
+    const router = await loadRouter();
+    expect(router.resolve('/link').matched.length).toBeGreaterThan(0);
+  });
+
+  it('carries ?from through, which is all that query is for', async () => {
     // It only changes what the page calls the bot. Nothing is decided by it.
+    const router = await loadRouter();
     const resolved = router.resolve('/link?from=discord');
     expect(resolved.matched.length).toBeGreaterThan(0);
     expect(resolved.query.from).toBe('discord');

--- a/tests/unit/bot-link.spec.ts
+++ b/tests/unit/bot-link.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiMe } from '@/api/me';
+import { http } from '@/api/client';
+import router from '@/router';
+
+vi.mock('@/api/client', () => ({
+  http: { post: vi.fn(() => Promise.resolve({ data: {} })) },
+}));
+
+describe('bot link code', () => {
+  beforeEach(() => {
+    vi.mocked(http.post).mockClear();
+  });
+
+  it('asks the API as the logged-in user', async () => {
+    await apiMe.createBotLinkCode('test-token-123');
+    const [path, body, config] = vi.mocked(http.post).mock.calls[0];
+    expect(path).toBe('/me/bot-link-codes/');
+    // Authenticated, because the code must only ever be issued to whoever is
+    // already signed in as the account being bound.
+    expect(config).toEqual({ headers: { Authorization: 'Bearer test-token-123' } });
+    expect(body).toEqual({});
+  });
+
+  it('sends no identifier for the bot', async () => {
+    // The backend never learns which platform is asking: the mapping from a
+    // platform account to a token lives in the bot, so nothing here names one.
+    await apiMe.createBotLinkCode('test-token-123');
+    const [, body] = vi.mocked(http.post).mock.calls[0];
+    expect(JSON.stringify(body)).not.toMatch(/discord|telegram/i);
+  });
+});
+
+describe('/link route', () => {
+  it('resolves, so the URL the bot prints actually lands somewhere', () => {
+    const resolved = router.resolve('/link');
+    expect(resolved.matched.length).toBeGreaterThan(0);
+  });
+
+  it('carries ?from through, which is all that query is for', () => {
+    // It only changes what the page calls the bot. Nothing is decided by it.
+    const resolved = router.resolve('/link?from=discord');
+    expect(resolved.matched.length).toBeGreaterThan(0);
+    expect(resolved.query.from).toBe('discord');
+  });
+});


### PR DESCRIPTION
## Related issues/discussions

The frontend half of a Discord bot that writes to Chafan on a user's behalf. Needs the backend endpoint from chafan-dev/chafan-core#204 (`POST /me/bot-link-codes/`) — until that ships, the button returns an error.

## Description of the changes

One page, one route, one API call. `/link` shows a button; pressing it returns a short-lived code the user carries to the bot.

- `src/views/BotLink.vue` — the page
- `src/api/me.ts` — `createBotLinkCode`
- `src/router.ts` — `/link`
- `src/interfaces/index.ts` — `IBotLinkCode`
- `tests/unit/bot-link.spec.ts`

### Why the code appears here rather than arriving from the bot

This is the whole reason the page exists, so it is worth stating: if the bot generated a key and put it in a URL, an attacker could start a link on their own bot session and send you the link. Your logged-in click would mint a token for **your** account under **their** key, and they would post as you. Nothing in that flow looks wrong — the right user clicked the right link on the right site.

Because the code appears here instead, on the screen of whoever is already signed in, the account that gets bound is always the one that asked, and only that person can hand the code over.

### The page names no bot

`?from=discord` changes one noun in the copy and decides nothing. Any holder of a configured secret can redeem a code, and this page has no way to know which bot the user will hand it to. That mirrors the backend's ignorance — the platform-account → token mapping lives in the bot — so a second bot on another platform reuses this page as it stands. A unit test asserts the request body carries no platform identifier.

### Three small deliberate choices

- **Logged out shows a login link, not a disabled button.** Being signed in is the precondition the design rests on, not an inconvenience to grey out.
- **There is a countdown.** A code that has quietly expired otherwise looks identical to one that has not, and the failure lands minutes later in a different app.
- **Copy failures are silent.** The clipboard is unavailable over plain http and in some embedded browsers; the code is on screen and short enough to retype, so it is not worth an error.

### Verification

- `vue-tsc --noEmit` — the new files add **0** errors to the 289 already on `master`
- `eslint` — 0 errors (formatting warnings are the pre-existing kind CLAUDE.md documents)
- `vite build` — clean, which per CLAUDE.md is the real check for template errors
- `vitest run` — **142 passed**, including 4 new

The new tests cover the API call, the absence of any platform identifier in it, and that `/link` resolves at all — that last one because the URL is printed by the bot, where a silent 404 would be discovered by a user rather than by us.

I have not driven this in a real browser: the page's only API call is an endpoint that does not exist in production yet, so the meaningful path can't be exercised until chafan-dev/chafan-core#204 lands. Worth a look on preview afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015AJVkkjMVCigkW9HbBFLM8