### PR TITLE
fix(profile): destructure meta so the profile form renders its save button

### DIFF
--- a/src/views/main/profile/UserProfileEdit.vue
+++ b/src/views/main/profile/UserProfileEdit.vue
@@ -2,7 +2,7 @@
   <v-container fluid>
     <v-row justify="center">
       <v-col :class="{ 'v-col-8': isDesktop }">
-        <Form v-slot="{ handleSubmit, resetForm }">
+        <Form v-slot="{ handleSubmit, resetForm, meta }">
           <div v-if="userProfile">
             <v-card-title>
               <div class="text-h5 text-primary">更新个人资料</div>


### PR DESCRIPTION
## Impact

**The profile edit page (`/profile/edit`) cannot be saved on production today.** The 保存 button is not disabled — it does not render at all, and neither do 取消 or 重置.

Found while testing whether a user can set an avatar. They can't: the image uploads fine and the preview updates, but `avatar_url` is only persisted by the save that can never happen. `GET /me` still returns `avatar_url: null` afterwards.

## Cause

`UserProfileEdit.vue:195` gates the button:

```vue
:disabled="!meta.valid || submitIntermediate"
```

but line 5 destructures only two of the slot props:

```vue
<Form v-slot="{ handleSubmit, resetForm }">
```

`meta` is undefined, so evaluating `meta.valid` throws during render:

```
TypeError: Cannot read properties of undefined (reading 'valid')
    at UserProfileEdit-BnzNCRwG.js:1:17109
```

Vue discards the subtree that threw — the entire `<v-card-actions>` — taking all three buttons with it.

Confirmed on https://cha.fan/profile/edit: `document.querySelectorAll('.v-card-actions').length === 0` and `/保存/.test(document.body.innerText) === false`, with the TypeError above in the console.

## Fix

```diff
-<Form v-slot="{ handleSubmit, resetForm }">
+<Form v-slot="{ handleSubmit, resetForm, meta }">
```

vee-validate 4.15.1's `slotProps()` returns `meta` alongside `handleSubmit` and `resetForm`, so naming it in the destructure is the whole fix:

```js
function slotProps() {
    return {
        meta: meta.value,
        errors: errors.value,
        ...
```

## Why this survived

It was already being reported by `vue-tsc`, as `UserProfileEdit.vue(195,29): error TS2339: Property 'meta' does not exist on type ...`. The typecheck has other pre-existing failures, so a real production outage sat in the noise. Worth considering whether that backlog gets a ratchet.

## Checks

- `vue-tsc --noEmit` — the TS2339 on line 195 is gone; the other pre-existing UserProfileEdit errors (lines 50, 300, 349) are untouched
- `vitest run` — 142 passed
- `eslint` on the changed file — clean
- `vite build` — succeeds

Not verified in a browser with the button rendering: that needs a deployed build or the local API, neither available here. The evidence is the type error clearing plus vee-validate's `slotProps()` source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)