### PR TITLE
fix(validation): let custom rules accept empty values instead of throwing

### DIFF
--- a/src/plugins/vee-validate.ts
+++ b/src/plugins/vee-validate.ts
@@ -10,6 +10,19 @@ defineRule('required', required);
 defineRule('email', email);
 defineRule('min', min);
 
+/**
+ * A rule other than `required` must accept an empty value and let `required`
+ * decide whether empty is allowed -- the vee-validate convention. Skipping
+ * this is not merely a style point: these rules call `String.match` on the
+ * value, so a null from an untouched optional field threw
+ * `Cannot read properties of null (reading 'match')` inside validation. The
+ * throw aborted the whole submission with no error shown and no request sent,
+ * which is how an empty 个人主页 silently made the profile form unsaveable.
+ */
+function isEmpty(value: unknown): boolean {
+  return value === null || value === undefined || value === '';
+}
+
 // Custom rules
 defineRule('password1', (value: string, [target]: string[]) => {
   if (value === target) return true;
@@ -17,21 +30,25 @@ defineRule('password1', (value: string, [target]: string[]) => {
 });
 
 defineRule('password', (value: string) => {
+  if (isEmpty(value)) return true;
   if (value.match(PasswordRegex) !== null) return true;
   return '密码必须至少8位，由数字、字母或者特殊符号组成';
 });
 
 defineRule('url', (value: string) => {
+  if (isEmpty(value)) return true;
   if (value.match(URLRegex) !== null) return true;
   return '无效的 URL';
 });
 
 defineRule('phone_number_e164', (value: string) => {
+  if (isEmpty(value)) return true;
   if (value.match(PhoneNumberRegex) !== null) return true;
   return '无效格式，有效格式的例子：+1222333444, +8611122223333';
 });
 
 defineRule('id', (value: string) => {
+  if (isEmpty(value)) return true;
   if (value.match(/^[\w-]+$/g) !== null) return true;
   return 'id 中仅允许使用字母数字、下划线和"-"，区分大小写';
 });

--- a/tests/unit/validation-rules.spec.ts
+++ b/tests/unit/validation-rules.spec.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest';
+import { vi, describe, expect, it } from 'vitest';
 import { validate } from 'vee-validate';
+
+// The plugin pulls the regexes from the `@/common` barrel, which transitively
+// reaches `@/env` -- and that module validates VITE_APP_API at import time and
+// throws when it is unset, as it is in CI. Same stub the other suites use.
+vi.mock('@/env', () => ({
+  apiUrl: 'https://api.test.cha.fan/api/v1',
+  wsUrl: 'wss://api.test.cha.fan/api/v1',
+  env: 'test',
+}));
 
 // Importing the plugin registers the rules globally via defineRule.
 import '@/plugins/vee-validate';

--- a/tests/unit/validation-rules.spec.ts
+++ b/tests/unit/validation-rules.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { validate } from 'vee-validate';
+
+// Importing the plugin registers the rules globally via defineRule.
+import '@/plugins/vee-validate';
+
+// An untouched optional field holds null, not ''. These rules used to call
+// String.match on it and throw inside validation, which aborted the whole
+// submission with no message and no request -- the profile form's 个人主页,
+// 知乎个人页 and Linkedin fields are all optional and all default to null.
+const EMPTY = [null, undefined, ''];
+
+describe('custom rules accept empty values', () => {
+  for (const rule of ['url', 'password', 'phone_number_e164', 'id']) {
+    for (const value of EMPTY) {
+      it(`${rule} passes ${JSON.stringify(value)} instead of throwing`, async () => {
+        const result = await validate(value, rule);
+        expect(result.valid).toBe(true);
+      });
+    }
+  }
+});
+
+describe('custom rules still reject bad values', () => {
+  const bad: [string, string][] = [
+    ['url', 'not a url'],
+    ['password', 'short'],
+    ['phone_number_e164', '12345'],
+    ['id', 'has spaces'],
+  ];
+  for (const [rule, value] of bad) {
+    it(`${rule} rejects ${JSON.stringify(value)}`, async () => {
+      const result = await validate(value, rule);
+      expect(result.valid).toBe(false);
+    });
+  }
+});
+
+describe('required still rejects empty', () => {
+  for (const value of EMPTY) {
+    it(`required rejects ${JSON.stringify(value)}`, async () => {
+      // Emptiness stays required's job; that is why the rules above may pass it.
+      const result = await validate(value, 'required');
+      expect(result.valid).toBe(false);
+    });
+  }
+});


### PR DESCRIPTION
Follow-up to #536. That PR made the 保存 button *render*; this one makes it *work*.

## Impact

`/profile/edit` still cannot be saved on production. Clicking 保存 does nothing at all — no request, no error message, no visible reaction. Verified on cha.fan against the deployed #536 build: a programmatic `.click()` on the button produces zero XHR and leaves the route on `/profile/edit`.

The only trace is one console line:

```
TypeError: Cannot read properties of null (reading 'match')
```

## Cause

The custom rules in `src/plugins/vee-validate.ts` call `String.match` with no emptiness check:

```ts
defineRule('url', (value: string) => {
  if (value.match(URLRegex) !== null) return true;
  return '无效的 URL';
});
```

An untouched optional field holds `null`, not `''`. The throw happens inside vee-validate's validation pass, so `handleSubmit` aborts before reaching the success callback — hence the total silence.

Three fields reach it: 个人主页, 知乎个人页 and Linkedin each render `ValidateUrl`, whose `rules="url"` has no `required` beside it because those fields are genuinely optional. On the account I tested, all three were null:

```json
{"homepage_url":null,"zhihu_url":null,"linkedin_url":null}
```

So **any account that hasn't filled in all three URL fields cannot save its profile** — which also makes avatar upload a dead end, since the image uploads fine but `avatar_url` is persisted only by the save.

## Fix

The vee-validate convention: a rule other than `required` accepts an empty value and lets `required` decide whether empty is allowed.

```ts
function isEmpty(value: unknown): boolean {
  return value === null || value === undefined || value === '';
}
```

Applied to all four rules that call `.match` (`url`, `password`, `phone_number_e164`, `id`), not just `url`, since the same latent throw sits in each.

**This does not weaken anything.** Every use of `password` and `id` is already paired with `required`:

| rule | usage |
| --- | --- |
| `id` | `rules="required\|id"` — CreateSiteCard, Signup |
| `password` | `rules="required\|password..."` — Security, Signup, ResetPassword |
| `url` | `rules="url"` alone — ValidateUrl, CreateSubmissionForm (**optional by design**) |
| `phone_number_e164` | no current usage |

## Tests

`tests/unit/validation-rules.spec.ts` asserts the empty cases pass, that bad values are still rejected, and that `required` still rejects empty. Reverting the fix makes them fail with the production error verbatim:

```
× url passes null instead of throwing
  → Cannot read properties of null (reading 'match')
```

## Checks

- `vitest run` — 161 passed (13 files)
- `eslint` on both changed files — clean
- `vue-tsc --noEmit` — output byte-identical before and after
- `vite build` — succeeds

Not yet verified in a browser, since it isn't deployed. Happy to re-run the full avatar flow on cha.fan once it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)