### PR TITLE
fix(profile): reset submitIntermediate in a finally so a failed save is retryable

### DIFF
--- a/src/views/main/profile/UserProfileEdit.vue
+++ b/src/views/main/profile/UserProfileEdit.vue
@@ -358,84 +358,91 @@ function cancel() {
 
 async function submit() {
   submitIntermediate.value = true;
-  await store.captureApiError(async () => {
-    const responses = await Promise.all(
-      newResidencyTopicNames.value.map((name) => apiTopic.createTopic(token.value, { name }))
-    );
-    userUpdateMe.residency_topic_uuids = responses.map((r) => r.data.uuid);
+  // The reset must be in a `finally`: `captureApiError` swallows the error, so
+  // a failed save returns here normally but skips the rest of the callback. A
+  // reset at the end of the callback therefore never runs, and 保存 stays
+  // disabled until the page is reloaded -- one transient failure kills the form.
+  try {
+    await store.captureApiError(async () => {
+      const responses = await Promise.all(
+        newResidencyTopicNames.value.map((name) => apiTopic.createTopic(token.value, { name }))
+      );
+      userUpdateMe.residency_topic_uuids = responses.map((r) => r.data.uuid);
 
-    const responses2 = await Promise.all(
-      newProfessionTopicNames.value.map((name) => apiTopic.createTopic(token.value, { name }))
-    );
-    userUpdateMe.profession_topic_uuids = responses2.map((r) => r.data.uuid);
+      const responses2 = await Promise.all(
+        newProfessionTopicNames.value.map((name) => apiTopic.createTopic(token.value, { name }))
+      );
+      userUpdateMe.profession_topic_uuids = responses2.map((r) => r.data.uuid);
 
-    const workExpsData = await Promise.all(
-      workExps.value.map(async (e) => {
-        if (e.company_topic_name && e.position_topic_name) {
-          const r1 = await apiTopic.createTopic(token.value, {
-            name: e.company_topic_name,
-          });
-          const r2 = await apiTopic.createTopic(token.value, {
-            name: e.position_topic_name,
-          });
-          return {
-            company_topic_uuid: r1.data.uuid,
-            position_topic_uuid: r2.data.uuid,
-          };
-        } else {
-          return null;
+      const workExpsData = await Promise.all(
+        workExps.value.map(async (e) => {
+          if (e.company_topic_name && e.position_topic_name) {
+            const r1 = await apiTopic.createTopic(token.value, {
+              name: e.company_topic_name,
+            });
+            const r2 = await apiTopic.createTopic(token.value, {
+              name: e.position_topic_name,
+            });
+            return {
+              company_topic_uuid: r1.data.uuid,
+              position_topic_uuid: r2.data.uuid,
+            };
+          } else {
+            return null;
+          }
+        })
+      );
+
+      userUpdateMe.work_experiences = [];
+      for (const e of workExpsData) {
+        if (e !== null) {
+          userUpdateMe.work_experiences.push(e);
         }
-      })
-    );
-
-    userUpdateMe.work_experiences = [];
-    for (const e of workExpsData) {
-      if (e !== null) {
-        userUpdateMe.work_experiences.push(e);
       }
-    }
 
-    const eduExpsData = await Promise.all(
-      eduExps.value.map(async (e) => {
-        if (e.school_topic_name && e.level_name) {
-          const r1 = await apiTopic.createTopic(token.value, {
-            name: e.school_topic_name,
-          });
-          return {
-            school_topic_uuid: r1.data.uuid,
-            level_name: e.level_name,
-            major: e.major,
-            enroll_year: e.enroll_year,
-            graduate_year: e.graduate_year,
-          };
-        } else {
-          return null;
+      const eduExpsData = await Promise.all(
+        eduExps.value.map(async (e) => {
+          if (e.school_topic_name && e.level_name) {
+            const r1 = await apiTopic.createTopic(token.value, {
+              name: e.school_topic_name,
+            });
+            return {
+              school_topic_uuid: r1.data.uuid,
+              level_name: e.level_name,
+              major: e.major,
+              enroll_year: e.enroll_year,
+              graduate_year: e.graduate_year,
+            };
+          } else {
+            return null;
+          }
+        })
+      );
+
+      userUpdateMe.education_experiences = [];
+      for (const e of eduExpsData) {
+        if (e !== null) {
+          userUpdateMe.education_experiences.push(e);
         }
-      })
-    );
-
-    userUpdateMe.education_experiences = [];
-    for (const e of eduExpsData) {
-      if (e !== null) {
-        userUpdateMe.education_experiences.push(e);
       }
-    }
 
-    const response = await apiMe.updateMe(token.value, userUpdateMe);
-    if (response) {
-      store.userProfile = response.data;
-      useNotificationStore().push({
-        content: '更新成功',
-        color: 'success',
-      });
-      await router.push({
-        name: 'user',
-        params: { handle: response.data.handle },
-        query: { details: 'true' },
-      });
-    }
+      const response = await apiMe.updateMe(token.value, userUpdateMe);
+      if (response) {
+        store.userProfile = response.data;
+        useNotificationStore().push({
+          content: '更新成功',
+          color: 'success',
+        });
+        await router.push({
+          name: 'user',
+          params: { handle: response.data.handle },
+          query: { details: 'true' },
+        });
+      }
+    });
+  } finally {
     submitIntermediate.value = false;
-  });
+  }
 }
 
 function addNewWorkExp() {


### PR DESCRIPTION
## Problem

One failed save permanently disables 保存. The form becomes unusable until the page is reloaded, with nothing on screen explaining why.

`submit()` set the flag back as the last statement *inside* the `captureApiError` callback:

```ts
submitIntermediate.value = true;
await store.captureApiError(async () => {
  ...
  const response = await apiMe.updateMe(token.value, userUpdateMe);
  if (response) { ... }
  submitIntermediate.value = false;   // never reached when updateMe throws
});
```

`captureApiError` swallows the error:

```ts
async captureApiError<T>(action: () => Promise<T>): Promise<T | undefined> {
  try { return await action(); }
  catch (err: unknown) { await this.checkApiError(err as AxiosError); }
},
```

so `submit()` returns normally while the rest of the callback — the reset included — is skipped. The button is bound to `:disabled="!meta.valid || submitIntermediate"`, so it stays greyed out forever.

## Reproduced

Profile saving currently fails on production: the API 503s on any non-null `avatar_url` (chafan-dev/chafan-core#207). After one click of 保存, on the live site:

```js
save.disabled === true
```

and no subsequent click produces a request. The user sees a button that stopped responding.

## Fix

```diff
   submitIntermediate.value = true;
-  await store.captureApiError(async () => {
+  try {
+    await store.captureApiError(async () => {
     ...
-    submitIntermediate.value = false;
-  });
+    });
+  } finally {
+    submitIntermediate.value = false;
+  }
```

A transient failure is now recoverable — fix the problem, press 保存 again.

## Scope note

The same shape — a spinner flag reset only on the success path inside a `captureApiError` callback — is common in this tree: **81** reset sites across views and components, and only **3** files use `finally` at all. Every one of them turns a transient API failure into a stuck control.

This PR fixes the single path where I actually reproduced the failure. The broader sweep is worth doing but belongs in its own change, ideally with a lint rule, rather than as an unverified bulk edit.

## Checks

- `vitest run` — 161 passed (run with `.env` moved aside, matching CI)
- `eslint` on the changed file — clean
- `vue-tsc --noEmit` — 5 UserProfileEdit errors, the same 5 pre-existing ones, unchanged
- `vite build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)