### PR TITLE
fix(avatar): guard against re-entrant uploads, and offer the formats the server takes

### DIFF
--- a/src/upload.ts
+++ b/src/upload.ts
@@ -34,6 +34,16 @@ export const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/png', 'image/gif', 'im
 /** For the `accept` attribute of a file input / the Vditor picker. */
 export const ACCEPTED_IMAGE_TYPES_ATTR = ACCEPTED_IMAGE_TYPES.join(', ');
 
+/**
+ * The same list without GIF, for the still-avatar picker. A GIF chosen there
+ * would bypass the canvas resize (`prepare` skips animated GIFs so they do not
+ * flatten to one frame) and land as an animated avatar, which is what the
+ * separate GIF avatar field already exists to do.
+ */
+export const ACCEPTED_STILL_IMAGE_TYPES_ATTR = ACCEPTED_IMAGE_TYPES.filter(
+  (type) => type !== 'image/gif'
+).join(', ');
+
 /** chafan-core `rules.MIN_KARMA_UPLOAD_IMAGE`. */
 export const MIN_KARMA_UPLOAD_IMAGE = 100;
 /** chafan-core `rules.UPLOAD_IMAGE_COST`, burned per *new* image. */

--- a/src/views/main/profile/UserProfileEdit.vue
+++ b/src/views/main/profile/UserProfileEdit.vue
@@ -22,7 +22,7 @@
                   </v-avatar>
                   <input
                     id="fileInput"
-                    accept="image/png, image/jpeg, image/bmp"
+                    :accept="ACCEPTED_STILL_IMAGE_TYPES_ATTR"
                     hidden
                     type="file"
                     @change="uploadAvatar"
@@ -228,6 +228,7 @@ import { useAuth, useImageUpload, useResponsive } from '@/composables';
 import { useMainStore } from '@/stores/main';
 import AppIcon from '@/components/icons/AppIcon.vue';
 import { useNotificationStore } from '@/stores/notifications';
+import { ACCEPTED_STILL_IMAGE_TYPES_ATTR } from '@/upload';
 const store = useMainStore();
 
 interface IUserWorkExperienceItem {
@@ -463,6 +464,13 @@ function removeFrom<T>(index: number, arr: T[]) {
 // The upload reports its own failures: an unhandled 403 would reach
 // store.checkApiError and log the user out.
 async function uploadAvatar() {
+  // A re-entrancy guard, not just a spinner: two change events -- a double
+  // pick, a retried pick -- otherwise start two concurrent uploads of the same
+  // new bytes, and the server charges UPLOAD_IMAGE_COST for each, because its
+  // dedup is an unlocked check-then-act (chafan-dev/chafan-core#206).
+  if (uploadAvatarIntermediate.value) {
+    return;
+  }
   const fileInput = document.getElementById('fileInput') as HTMLInputElement | null;
   const file = fileInput?.files?.[0];
   if (!file) {
@@ -485,6 +493,9 @@ async function uploadAvatar() {
 }
 
 async function uploadGifAvatar() {
+  if (uploadGifAvatarIntermediate.value) {
+    return;
+  }
   const fileInput = document.getElementById('gifFileInput') as HTMLInputElement | null;
   const file = fileInput?.files?.[0];
   if (!file) {

--- a/tests/unit/upload.spec.ts
+++ b/tests/unit/upload.spec.ts
@@ -37,6 +37,8 @@ vi.mock('@sentry/vue', () => ({
 }));
 
 import {
+  ACCEPTED_IMAGE_TYPES_ATTR,
+  ACCEPTED_STILL_IMAGE_TYPES_ATTR,
   MAX_IMAGE_BYTES,
   MIN_KARMA_UPLOAD_IMAGE,
   UPLOAD_IMAGE_COST,
@@ -269,5 +271,22 @@ describe('vditorUploadOptions', () => {
 
     await expect(options.handler([png()])).resolves.toBe('硬币不足');
     expect(inserted).toEqual([]);
+  });
+});
+
+describe('ACCEPTED_STILL_IMAGE_TYPES_ATTR', () => {
+  it('offers every still format the server accepts', () => {
+    // bmp used to be offered here and is a 415 on the server; webp is
+    // supported and used to be missing. Deriving from ACCEPTED_IMAGE_TYPES
+    // keeps the picker and the contract from drifting apart again.
+    expect(ACCEPTED_STILL_IMAGE_TYPES_ATTR).toContain('image/jpeg');
+    expect(ACCEPTED_STILL_IMAGE_TYPES_ATTR).toContain('image/png');
+    expect(ACCEPTED_STILL_IMAGE_TYPES_ATTR).toContain('image/webp');
+    expect(ACCEPTED_STILL_IMAGE_TYPES_ATTR).not.toContain('image/bmp');
+  });
+
+  it('leaves GIF to the dedicated GIF avatar field', () => {
+    expect(ACCEPTED_STILL_IMAGE_TYPES_ATTR).not.toContain('image/gif');
+    expect(ACCEPTED_IMAGE_TYPES_ATTR).toContain('image/gif');
   });
 });


### PR DESCRIPTION
Two problems in the avatar picker, both in the same few lines of `UserProfileEdit.vue`.

## 1. `uploadAvatarIntermediate` was never a guard

It was set and cleared, but never *checked*, so it drove the spinner and nothing else:

```ts
async function uploadAvatar() {
  const file = ...;
  uploadAvatarIntermediate.value = true;   // set, never read
```

Two change events — a double pick, a retried pick — start two concurrent uploads of the same new bytes. The server charges `UPLOAD_IMAGE_COST` for each, because its dedup is an unlocked check-then-act and both requests see the sha as new (chafan-dev/chafan-core#206).

Observed on cha.fan during testing: one avatar upload, **one** stored object, **four** coins (978 → 974). A later identical upload was correctly free, which is why this is invisible unless you watch the balance across the first one.

Checking the flag on entry costs nothing and closes the client half of that race. Applied to `uploadGifAvatar` too — same shape.

## 2. The `accept` list contradicted the server

```diff
-accept="image/png, image/jpeg, image/bmp"
+:accept="ACCEPTED_STILL_IMAGE_TYPES_ATTR"
```

`image/bmp` is a **415** on the server; `image/webp` is accepted and was missing. BMP only ever appeared to work because the canvas resize re-encodes everything to JPEG before the bytes are sent — a coincidence that would break the moment that pass changes.

The new constant derives from `ACCEPTED_IMAGE_TYPES`, which already mirrors the server's `_SUPPORTED_FORMATS`, so the picker can't drift from the contract again:

```ts
export const ACCEPTED_STILL_IMAGE_TYPES_ATTR = ACCEPTED_IMAGE_TYPES.filter(
  (type) => type !== 'image/gif'
).join(', ');
```

**Why minus GIF:** a GIF chosen in the still slot would skip the canvas resize — `prepare` deliberately spares animated GIFs so they don't flatten to one frame — and land as an animated avatar, duplicating the dedicated GIF field. That field's own `accept="image/gif"` is unchanged.

## Tests

Two cases added to `tests/unit/upload.spec.ts`: the still list offers every still format the server takes and excludes BMP, and GIF stays out of it while remaining in the full list.

## Checks

- `vitest run` — 163 passed (run with `.env` moved aside, matching CI)
- `eslint` on all three changed files — clean
- `vite build` — succeeds

## Not covered

This is the client half only. The server can still be made to double-charge by any client that fires two concurrent uploads; that needs chafan-dev/chafan-core#206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)