### PR TITLE
fix(contrib): widen the year select so the year is not clipped to "2··"

### DIFF
--- a/src/components/widgets/ContribGraphs.vue
+++ b/src/components/widgets/ContribGraphs.vue
@@ -6,8 +6,14 @@
       :key="pair.year"
       v-show="year === pair.year"
     />
+    <!--
+      max-w-80 (80px) came from Vuetify 2, whose select was narrower. Under
+      Vuetify 3 the compact select's own padding plus the dropdown arrow leave
+      too little room for a four-digit year, and "2026" renders ellipsised as
+      "2··". 100px fits it.
+    -->
     <v-select
-      class="max-w-80"
+      class="max-w-100"
       v-model="year"
       :items="data.map((p) => p.year)"
       density="compact"


### PR DESCRIPTION
## Problem

The contribution graph's year select renders the year as **`2··`** on every user profile, e.g. https://cha.fan/users/chai_inu.

The value is correct — `textContent` is `"2026"` — it's the box that's too small.

## Cause

`ContribGraphs.vue:10` carried `class="max-w-80"` → `max-width: 80px` (`app.scss:37`). That was enough under Vuetify 2. Vuetify 3's `density="compact"` select spends more of that box on its own padding and the dropdown arrow, so the selection text is left with a fraction of what it needs.

Measured on the live page:

| max-width | text scrollWidth | text clientWidth | clipped |
| --- | --- | --- | --- |
| 80px (current) | 36 | 18 | **yes** |
| 100px | 36 | 36 | no |

## Fix

`max-w-80` → `max-w-100`, a utility that already exists in `app.scss:41`. Verified in the browser at 100px — "2026" renders in full.

Another silent Vuetify 2 → 3 sizing carry-over of the kind CLAUDE.md warns about: no error, no warning, just a wrong-looking control.

## Checks

- `vitest run` — 161 passed (run with `.env` moved aside, matching CI)
- `eslint` on the changed file — clean
- `vite build` — succeeds
- Verified visually in Chrome against production

🤖 Generated with [Claude Code](https://claude.com/claude-code)